### PR TITLE
Server comms for setup and cal pages

### DIFF
--- a/app/components/VialSelector.js
+++ b/app/components/VialSelector.js
@@ -53,7 +53,7 @@ class List extends Component {
       <div style={{width: 560}}>
         <div className="centered">
           {this.props.items.map((item) => (
-            <SelectableAlbum key={item.vial} vial={item.vial} selected={item.selected} od={item.od} temp={item.temp}/>
+            <SelectableAlbum key={item.vial} vial={item.vial} selected={item.selected} od={item.od135} temp={item.temp}/>
           ))}
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: Zachary Heins <zackheins@gmail.com>

# What? Why?
Because the eVOLVER server has undergone some refactoring, the downstream applications need to be updated to properly interface.

NOTE: This does not completely fix everything - still need to handle the multiple od experimental params (90 and 135). Currently just reading and displaying the 135 and using old calibration sigmoid functions. Ideally it should detect which type of cal function to use based on the broadcasted data.

Changes proposed in this pull request:
- Setup page sends commands appropriately and updates vial data from broadcast
- Density calibration page works off of broadcasted data. No longer has multiple power level settings
- Temperature calibration page works off of broadcasted data, updated command to correct format.

# Checks
- [ ] Updated documentation. (the whole thing needs documentation - that will come later.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
