### PR TITLE
Convert responses from server to int before saving

### DIFF
--- a/app/components/DensityCalibrate.js
+++ b/app/components/DensityCalibrate.js
@@ -90,9 +90,9 @@ class ODcal extends React.Component {
 
         // Add the data into the data structures
         for (var i = 0; i < response.data.od_135.length; i++) {
-            newVialData.od135[i][this.state.currentStep - 1].push(response.data.od_135[i]);
-            newVialData.od90[i][this.state.currentStep - 1].push(response.data.od_90[i]);
-            newVialData.temp[i][this.state.currentStep - 1].push(response.data.temp[i]);
+            newVialData.od135[i][this.state.currentStep - 1].push(parseInt(response.data.od_135[i]));
+            newVialData.od90[i][this.state.currentStep - 1].push(parseInt(response.data.od_90[i]));
+            newVialData.temp[i][this.state.currentStep - 1].push(parseInt(response.data.temp[i]));
         }
         var progressCompleted = (100 * ((this.state.readsFinished) / 16));
         var readProgress = this.state.readProgress;

--- a/app/components/TempCalibrate.js
+++ b/app/components/TempCalibrate.js
@@ -145,7 +145,7 @@ class TempCal extends React.Component {
           if (newVialData[newVialData.length - 1].temp.length <= i) {
               newVialData[newVialData.length - 1].temp.push([]);
           }
-          newVialData[newVialData.length - 1].temp[i].push(response.data.temp[i]);
+          newVialData[newVialData.length - 1].temp[i].push(parseInt(response.data.temp[i]));
       }
       this.setState({
         tempStream: tempStream,


### PR DESCRIPTION
# What? Why?
When performing calibrations, the .json file would have all values saved as Strings, which is inconvenient for downstream processing that needs the data in numerical form.

Changes proposed in this pull request:
- Parse the string responses from the server into an integer before saving the data

