### PR TITLE
Fixing command log with new server

### DIFF
--- a/app/components/setupButtons/SetupLog.js
+++ b/app/components/setupButtons/SetupLog.js
@@ -105,14 +105,15 @@ class SetupLog extends React.Component {
           outputString = 'Response: ' + value + ' ON for ' + data.value.time + 's, vials (' + triggeredVials + ')'
         }
       } else {
-        var vials = data['message']
+        var vials = data['value'];
+	      var value = [];
         for (var i = 0; i < vials.length; i++) {
           if (vials[i] !== 'NaN'){
             triggeredVials = triggeredVials + i + ',';
             if (data['param'] == "temp"){
-              value = data['value'] + '\u00b0C';
+              value.push(data['value'][i]);// + '\u00b0C');
             } else {
-              value = data['value']
+              value.push(data['value'][i]);
             }
           }
         }


### PR DESCRIPTION
# What? Why?
The new server removed and changed how data is processed and sent to the setup page. This allows the response to be displayed again with the new server

Changes proposed in this pull request:
- Update `SetupLog.js` to display `commandbroadcast` data from server
