### PR TITLE
Adding a download button for data within app

### DIFF
--- a/app/components/Graph.css
+++ b/app/components/Graph.css
@@ -31,7 +31,7 @@
   background-color: black;
   border: 1px solid white;
   position: absolute;
-  top: 447px;
+  top: 392px;
   left: 27px;
   color: orange;
   font-size: 17px;
@@ -49,4 +49,15 @@
   top: 37px;
   left: 70px;
   z-index: 10;
+}
+
+.downloadButton {
+  position: absolute;
+  top: 550px;
+  left: 60px;
+  width: 150px;
+}
+
+.downloadButton:active {
+  background: grey;
 }

--- a/app/components/Graph.js
+++ b/app/components/Graph.js
@@ -9,7 +9,12 @@ import VialArrayGraph from './graphing/VialArrayGraph';
 import VialArrayBtns from './graphing/VialArrayBtns';
 import VialMenu from './graphing/VialMenu';
 
+const { dialog } = require('electron').remote
+
 var path = require('path');
+var os = require('os');
+var zipdir = require('zip-dir');
+var fs = require('fs');
 
 const styles = {
 
@@ -90,6 +95,20 @@ class Graph extends React.Component {
     })
   }
 
+  downloadData = () => {    
+    var pathToDownload;
+    var isWin = os.platform() === 'win32';
+    if (!isWin) {
+      pathToDownload  = dialog.showOpenDialog({ properties: ['openDirectory', 'createDirectory']});
+    }
+    else {
+      pathToDownload = dialog.showOpenDialog({properties: ['openDirectory', 'promptToCreate']});
+    }
+
+    var zipFilename = path.join(pathToDownload[0], path.basename(this.props.exptDir) + '.zip');      
+    zipdir(this.props.exptDir, {saveTo: zipFilename});
+  }
+
   handleActivePlot = (event) => {
     this.setState({activePlot: event})
   }
@@ -108,14 +127,14 @@ class Graph extends React.Component {
           timePlotted={this.state.timePlotted}
           downsample = {this.state.downsample}
           xaxisName = {this.state.xaxisName}/>
-        <div style={{position: 'absolute', top: '155px', left: '-10px'}}>
+        <div style={{position: 'absolute', top: '100px', left: '-10px'}}>
           <VialArrayBtns
             labels={this.state.parameterChoices}
             radioTitle = {this.state.parameterTitle}
             value={this.state.parameter}
             onSelectRadio={this.handleParameterSelect}/>
         </div>
-        <div style={{position: 'absolute', top: '240px', left: '-10px'}}>
+        <div style={{position: 'absolute', top: '185px', left: '-10px'}}>
           <VialArrayBtns
             labels={this.state.timePlottedChoices}
             radioTitle = {this.state.timePlottedTitle}
@@ -128,6 +147,7 @@ class Graph extends React.Component {
             onSelectRadio={this.handleYmax}/>
         </div>
         <VialMenu onSelectGraph={this.handleActivePlot}/>
+        <button className={"downloadButton"} onClick={this.downloadData}>DOWNLOAD</button>
       </div>
 
     );

--- a/app/components/graphing/VialMenu.js
+++ b/app/components/graphing/VialMenu.js
@@ -27,15 +27,15 @@ class VialMenu extends React.Component {
 
       <div style={{
         width:'300px',
-        height: '300px'}}>
+        height: '500px'}}>
 
-        <p style={{fontSize: '21px', fontWeight: 'bold', position: 'absolute', margin: '405px 0px 0px 40px' }}>INDIVIDUAL PLOTS</p>
+        <p style={{fontSize: '21px', fontWeight: 'bold', position: 'absolute', margin: '350px 0px 0px 40px' }}>INDIVIDUAL PLOTS</p>
         <div style={{
           width:'220px',
           height: '200px',
           padding: '0px 40px 0px 40px',
           position: 'absolute',
-          margin: '445px 0px 0px 75px'}}>
+          margin: '390px 0px 0px 75px'}}>
           {vialButtons.map((vialButton, index) => (
             <button
               className = 'vialPlotsMenuBtns'

--- a/package.json
+++ b/package.json
@@ -254,7 +254,8 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "socket.io-client": "^2.2.0",
-    "source-map-support": "^0.5.6"
+    "source-map-support": "^0.5.6",
+    "zip-dir": "2.0.0"
   },
   "devEngines": {
     "node": ">=7.x",


### PR DESCRIPTION
# What? Why?
Allows user to retreive data from the app's internal working area and put it anywhere they want on their file system.

Changes proposed in this pull request:
- adding a button to the graph component
- When pressed, the experiment directory is compressed and saved to whereever the user wants.

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

<img width="1107" alt="Screen Shot 2021-01-11 at 6 50 18 PM" src="https://user-images.githubusercontent.com/10240498/104251558-fe3bc400-543d-11eb-80f9-4a776542ed2c.png">
<img width="1096" alt="Screen Shot 2021-01-11 at 6 50 35 PM" src="https://user-images.githubusercontent.com/10240498/104251554-fc720080-543d-11eb-8eaf-38973ab517f7.png">
<img width="1081" alt="Screen Shot 2021-01-11 at 6 50 59 PM" src="https://user-images.githubusercontent.com/10240498/104251552-fc720080-543d-11eb-81ff-eaac886e5336.png">