### PR TITLE
Links dependent on OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ Package for Raspberry Pi:
 $ yarn package-rpi
 ```
 
+Next, scp the file to the Raspberry Pi:
+
+```bash
+$ scp release/evolver-electron-1.0.0.AppImage pi@<RPI_IP>:~/evolver-electron-1.0.0.AppImage-new
+```
+
+NOTE: Do not directly overwrite the file - add `-new` to the end so that it copies next to the current build.
+
+Now ssh to the Raspberry Pi, backup the old version and replace it with the new. Restart the raspberry pi to finish the installation.
+
+```bash
+$ ssh pi@<RPI_IP>
+$ mv evolver-electron-1.0.0.AppImage evolver-electron-1.0.0.AppImage-old
+$ mv evolver-electron-1.0.0.AppImage-new evolver-electron-1.0.0.AppImage
+$ sudo reboot now
+```
+
 ## Credit
 
 - [Zachary Heins](https://github.com/zheins)

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -123,6 +123,12 @@ export default class Home extends Component<Props> {
   }
 
   render() {
+    var links = (isPi() ? <div><Link to={{pathname:routes.SETUP, socket:this.state.socket, logger:this.logger}}><button className = "btn btn-lg homeButtons">SETUP</button></Link></div> :
+      <div>
+        <Link to={{pathname:routes.SETUP, socket:this.state.socket, logger:this.logger}}><button className = "btn btn-lg homeButtons">SETUP</button></Link>
+        <Link to={{pathname:routes.CALMENU, socket:this.state.socket, logger:this.logger}}><button className = "btn btn-lg homeButtons">CALIBRATIONS</button></Link>
+        <Link to={{pathname:routes.EXPTMANAGER, socket:this.state.socket, logger:this.logger, evolverIp: this.state.evolverIp}}><button className = "btn btn-lg homeButtons">EXPT MANAGER</button></Link>
+      </div>);
 
     return (
       <div>
@@ -131,10 +137,7 @@ export default class Home extends Component<Props> {
             <div className="p-5"/>
             <h1 className="display-2 centered">eVOLVER</h1>
             <p className="font-italic"> Continuous Culture </p>
-
-            <Link to={{pathname:routes.SETUP, socket:this.state.socket, logger:this.logger}}><button className = "btn btn-lg homeButtons">SETUP</button></Link>
-            <Link to={{pathname:routes.CALMENU, socket:this.state.socket, logger:this.logger}}><button className = "btn btn-lg homeButtons">CALIBRATIONS</button></Link>
-            <Link to={{pathname:routes.EXPTMANAGER, socket:this.state.socket, logger:this.logger, evolverIp: this.state.evolverIp}}><button className = "btn btn-lg homeButtons">EXPT MANAGER</button></Link>
+            {links}
         </div>
         <div className='homeConfigBtn'>
           <ConfigModal socket= {this.state.socket} isPi= {this.state.isPi}  onSelectEvolver={this.handleSelectEvolver}/>


### PR DESCRIPTION
# What? Why?
The RPi build should not display the links to access the experiment manager or the calibration menu. Experiments should be run on the computer, not RPi (lack of mem/processing power). The calibration menu also can run into issues when being run on the RPi.

Addresses #82 

Changes proposed in this pull request:
- Links are placed into a div whose contents are dependent on the previously existing `isPi()` function.

# Checks
- [ ] Updated documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
<img width="1095" alt="Screen Shot 2021-01-13 at 7 52 02 PM" src="https://user-images.githubusercontent.com/10240498/104529930-d6cd2e80-55d8-11eb-8cb8-e03350825abe.png">
