### PR TITLE
Store running experiments and PID in electron memory

### DIFF
--- a/app/background.html
+++ b/app/background.html
@@ -72,11 +72,11 @@
 
 
 	ipcRenderer.on('start', (event, arg) => {
-	 	console.log(arg);		
-		var scriptName = arg + '/eVOLVER.py';		
+		console.log(arg);
+		var scriptName = arg + '/eVOLVER.py';
 		var options = {
 			mode: 'text',
-            args: ['--always-yes']
+			args: ['--always-yes']
 			//pythonPath: '/Library/Frameworks/Python.framework/Versions/3.6/bin/python3',
 			//args: ['-z', arg['zero'], '-o', arg['overwrite'], '-c', arg['continue'], '-p', JSON.stringify(arg['parameters']), '-i', arg['evolver-ip'], '-t', arg['evolver-port'], '-n', arg['name'], '-b', arg['blank']]
 		};
@@ -87,6 +87,8 @@
 			console.log(message);
 			logger.info(message);
 		});
+		var pid = pyShell.childProcess.pid;
+		ipcRenderer.send('store-pid', [arg, pid]);
 	});
 	ready();
 </script>

--- a/app/components/ExptManager.js
+++ b/app/components/ExptManager.js
@@ -45,7 +45,7 @@ function startScript(exptDir) {
 
 class ExptManager extends React.Component {
   constructor(props) {
-    super(props);  
+    super(props);
     this.state = {
       scriptDir: 'experiments',
       activeScript: '',
@@ -144,7 +144,7 @@ class ExptManager extends React.Component {
           if (fs.existsSync(path.join(oldDir, filename))) {
             fs.copyFileSync(path.join(oldDir, filename), path.join(newDir, filename));
           }
-        });      
+        });
         this.setState({refind: !this.state.refind});
     }
 


### PR DESCRIPTION
# What? Why?
Store running experiments and PID in electron memory. 
Enables user to track running experiments in the event app crashes/closes unintentionally. 

Addresses #68 

Changes proposed in this pull request:
- create key in config.json in electron memory called `running_expts` 
- save JSON array under `running_expts` to track running experiments, each structured as {experiment_path:PID} 
- update `running_expts` JSON array after experiments are started/closed

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
