### PR TITLE
Kill and restart experiments found in electron memory. Prompt user of…

### DIFF
--- a/app/background.html
+++ b/app/background.html
@@ -72,11 +72,11 @@
 
 
 	ipcRenderer.on('start', (event, arg) => {
-		console.log(arg);
-		var scriptName = arg + '/eVOLVER.py';
+		console.log(arg.scriptDir);
+		var scriptName = arg.scriptDir + '/eVOLVER.py';
 		var options = {
 			mode: 'text',
-			args: ['--always-yes']
+			args: arg.flag
 			//pythonPath: '/Library/Frameworks/Python.framework/Versions/3.6/bin/python3',
 			//args: ['-z', arg['zero'], '-o', arg['overwrite'], '-c', arg['continue'], '-p', JSON.stringify(arg['parameters']), '-i', arg['evolver-ip'], '-t', arg['evolver-port'], '-n', arg['name'], '-b', arg['blank']]
 		};
@@ -88,7 +88,7 @@
 			logger.info(message);
 		});
 		var pid = pyShell.childProcess.pid;
-		ipcRenderer.send('store-pid', [arg, pid]);
+		ipcRenderer.send('store-pid', [arg.scriptDir, pid]);
 	});
 	ready();
 </script>

--- a/app/components/RelaunchModal.js
+++ b/app/components/RelaunchModal.js
@@ -1,0 +1,95 @@
+// @flow
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { withStyles } from '@material-ui/core/styles';
+import Modal from 'react-responsive-modal';
+import styles from './modal-styling.css';
+
+
+const cardStyles = {
+
+};
+
+class RelaunchModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: this.props.alertOpen,
+      question: this.props.alertQuestion,
+      experiments: this.props.alertExperiments,
+      answers: this.props.alertAnswers
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.alertOpen !== prevProps.alertOpen) {
+      this.setState({ open: this.props.alertOpen})
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+      this.setState({open:nextProps.alertOpen});
+  }
+
+  onOpenModal = () => {
+    this.setState({ open: true, input:''});
+  };
+
+  onCloseModal = () => {
+    this.setState({open: false, value:''});
+  };
+
+  onYes = () => {
+    this.props.onClickYes();
+    this.setState({open: false});
+  };
+
+  onNo = () => {
+    this.props.onClickNo();
+    this.setState({open: false});
+  };
+
+  render() {
+    const { open } = this.state;
+
+    return (
+      <div>
+        <Modal
+          open={open}
+          onClose={this.onCloseModal}
+          onRequestClose={this.onCloseModal}
+          center
+          classNames={{
+             closeButton: styles.alertCloseButton,
+             modal: styles.newExptModal,
+             overlay: styles.customOverlay
+           }}>
+           <div style={{height: 'auto'}}>
+              <p style={{textAlign: 'center', margin: '10px 5px 5px 5px', fontSize: '20px'}}>
+                {this.state.question}
+              </p>
+              <p style={{whiteSpace: 'pre', textAlign: 'center', margin: '0px 5px 5px 5px', fontSize: '20px'}}>
+                {this.state.experiments}
+              </p>
+              <div className='alertBtnRow' style={{margin: '0px 30px 0px 30px'}}>
+                <button
+                  onClick={this.onYes}
+                  className={styles.alertBtns}>
+                  Yes
+                </button>
+                <button
+                  onClick={this.onNo}
+                  className={styles.alertBtns}>
+                  No
+                </button>
+              </div>
+            </div>
+          </Modal>
+      </div>
+
+    );
+  }
+}
+
+export default withStyles(cardStyles)(RelaunchModal);


### PR DESCRIPTION
… potential running experiments when quitting application.

Ensures that running experiments found on the computer are connected to the application. 

Changes proposed in this pull request:
- Modal pops up on home screen on launch to inform users if there are running experiments that match those stored in electron memory. User can than either (a) kill and relaunch experiments to bring them under control of the application or (b) only kill them
- Dialog pops up when quitting app to inform users of any running experiments. Running experiments are not killed if app is closed.

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
<img width="1097" alt="Screen Shot 2021-01-21 at 8 31 01 PM" src="https://user-images.githubusercontent.com/36025985/105440466-9868ec80-5c34-11eb-89ee-1978d8c420b9.png">

<img width="1101" alt="Screen Shot 2021-01-21 at 8 31 22 PM" src="https://user-images.githubusercontent.com/36025985/105440492-a4ed4500-5c34-11eb-936d-4e24c27271f5.png">

<img width="1102" alt="Screen Shot 2021-01-21 at 8 32 09 PM" src="https://user-images.githubusercontent.com/36025985/105440513-ab7bbc80-5c34-11eb-8176-6d43b939325f.png">

App re-launches experiments alongside with newly started experiments
<img width="1092" alt="Screen Shot 2021-01-21 at 8 34 37 PM" src="https://user-images.githubusercontent.com/36025985/105440522-afa7da00-5c34-11eb-8035-1977300d1fde.png">

