### PR TITLE
Setup page active pumpcal

### DIFF
--- a/app/components/Setup.js
+++ b/app/components/Setup.js
@@ -24,8 +24,10 @@ export default class Setup extends Component<Props> {
             vialData: data,
             tempCalFiles: [],
             odCalFiles: [],
+            pumpCalFile: [],
             activeTempCal: 'Retreiving...',
             activeODCal: 'Retreiving...',
+            activePumpCal: 'Retreiving...',
             tempCal: {},
             odCal: {},
             command: {},
@@ -40,6 +42,7 @@ export default class Setup extends Component<Props> {
       this.props.socket.on('fitnames', function(response) {
         var odCalFiles = [];
         var tempCalFiles = [];
+        var pumpCalFiles = [];
         for (var i = 0; i < response.length; i++) {
             if (response[i].calibrationType == "od") {
               odCalFiles.push(response[i].name);
@@ -47,28 +50,36 @@ export default class Setup extends Component<Props> {
             else if (response[i].calibrationType == "temperature") {
               tempCalFiles.push(response[i].name);
             }
+            else if (response[i].calibrationType == "pump") {
+              pumpCalFiles.push(response[i].name);
+            }
         }
-        this.setState({odCalFiles: odCalFiles, tempCalFiles: tempCalFiles})
+        this.setState({odCalFiles: odCalFiles, tempCalFiles: tempCalFiles, pumpCalFiles: pumpCalFiles})
 
       }.bind(this))
       this.props.socket.on('activecalibrations', function(response) {
         var activeODCal;
         var activeTempCal;
+        var activePumpCal;
         for (var i = 0; i < response.length; i++) {
           for (var j = 0; j < response[i].fits.length; j++) {
             if (response[i].fits[j].active) {
               if (response[i].calibrationType == 'od') {
-                activeODCal = response[i].fits[j]
+                activeODCal = response[i].fits[j];
               }
               else if (response[i].calibrationType == 'temperature') {
-                activeTempCal = response[i].fits[j]
+                activeTempCal = response[i].fits[j];
+              }
+              else if (response[i].calibrationType == 'pump') {
+                activePumpCal = response[i].fits[j];
               }
             }
           }
         }
-        this.setState({odCal: activeODCal, tempCal: activeTempCal, activeODCal: activeODCal.name, activeTempCal: activeTempCal.name});
+        this.setState({odCal: activeODCal, tempCal: activeTempCal, activeODCal: activeODCal.name, activeTempCal: activeTempCal.name, activePumpCal: activePumpCal.name});
         store.set('activeODCal', activeODCal.name);
         store.set('activeTempCal', activeTempCal.name);
+        store.set('activePumpCal', activePumpCal.name);
         }.bind(this))
     }
 
@@ -81,8 +92,9 @@ export default class Setup extends Component<Props> {
     initialData = this.formatVialSelectStrings(initialData, 'temp');
     this.setState({
       vialData: initialData,
-      activeODCal:store.get('activeODCal'),
-      activeTempCal:store.get('activeTempCal'),
+        activeODCal: store.get('activeODCal'),
+        activeTempCal: store.get('activeTempCal'),
+        activePumpCal: store.get('activePumpCal')
       });
   };
 
@@ -195,6 +207,9 @@ export default class Setup extends Component<Props> {
       this.setState({showRawTemp: false});
       this.handleRawData(this.state.rawVialData, this.state.showRawOD, false)
     }
+    if (parameter == 'pump') {
+      this.props.socket.emit("setactivecal", {'calibration_names': filenames});
+    }
     if (parameter == 'rawod'){
       this.setState({showRawOD: !this.state.showRawOD});
       this.handleRawData(this.state.rawVialData, !this.state.showRawOD, this.state.showRawTemp)
@@ -269,8 +284,10 @@ export default class Setup extends Component<Props> {
                   onSubmitButton={this.onSubmitButton}
                   activeTempCal={this.state.activeTempCal}
                   activeODCal={this.state.activeODCal}
+                  activePumpCal={this.state.activePumpCal}
                   tempCalFiles= {this.state.tempCalFiles}
                   odCalFiles={this.state.odCalFiles}
+                  pumpCalFiles={this.state.pumpCalFiles}
                   showRawTemp= {this.state.showRawTemp}
                   showRawOD= {this.state.showRawOD}
                   onSelectNewCal = {this.onSelectNewCal}
@@ -281,7 +298,8 @@ export default class Setup extends Component<Props> {
                 ref={this.child}
                 command={this.state.command}
                 activeTempCal={this.state.activeTempCal}
-                activeODCal={this.state.activeODCal}/>
+                activeODCal={this.state.activeODCal}
+                activePumpCal={this.state.activePumpCal}/>
               <div>
                 <VialSelector
                   items={this.state.vialData}

--- a/app/components/dashboard-layout.css
+++ b/app/components/dashboard-layout.css
@@ -48,7 +48,7 @@
   font-size: 16px;
   font-style: italic;
   position: absolute;
-  top: 155px;
+  top: 170px;
   left: 0px;
   width: 100%;
   text-align: center;

--- a/app/components/setupButtons/ButtonCards.js
+++ b/app/components/setupButtons/ButtonCards.js
@@ -68,11 +68,11 @@ const styles = theme => ({
   },
   card: {
     width: 440,
-    height: 190,
+    height: 195,
     backgroundColor: 'black',
   },
   cardSpacer: {
-    height: 15,
+    height: 10,
     backgroundColor: 'black',
   },
   stepperStyle: {
@@ -108,7 +108,15 @@ function ActiveButtons(props) {
     return <LightButtons onSubmitButton={props.onSubmitButton}/>;
   }
   if (currentTag == 'calibrate') {
-    return <CalibrationButtons onSelectNewCal={props.onSelectNewCal}  tempCalFiles= {props.tempCalFiles} odCalFiles={props.odCalFiles}activeTempCal={props.activeTempCal} activeODCal={props.activeODCal} showRawTemp= {props.showRawTemp} showRawOD= {props.showRawOD}/>
+    return <CalibrationButtons onSelectNewCal={props.onSelectNewCal}
+              tempCalFiles = {props.tempCalFiles}
+              odCalFiles = {props.odCalFiles}
+              pumpCalFiles = {props.pumpCalFiles}
+              activeTempCal = {props.activeTempCal}
+              activeODCal = {props.activeODCal}
+              activePumpCal = {props.activePumpCal}
+              showRawTemp = {props.showRawTemp}
+              showRawOD = {props.showRawOD}/>
   }
   return null;
 }
@@ -120,8 +128,10 @@ class SwipeableTextMobileStepper extends React.Component {
       activeStep: 0,
       activeTempCal: this.props.activeTempCal,
       activeODCal: this.props.activeODCal,
+      activePumpCal: this.props.activePumpCal,
       tempCalFiles: this.props.tempCalFiles,
       odCalFiles: this.props.odCalFiles,
+      pumpCalFiles: this.props.pumpCalFiles,
       showRawTemp: this.props.showRawTemp,
       showRawOD: this.props.showRawOD
     };
@@ -129,22 +139,28 @@ class SwipeableTextMobileStepper extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.activeTempCal !== prevProps.activeTempCal) {
-      this.setState({ activeTempCal: this.props.activeTempCal})
+      this.setState({ activeTempCal: this.props.activeTempCal});
     }
     if (this.props.activeODCal !== prevProps.activeODCal) {
-      this.setState({ activeODCal: this.props.activeODCal})
+      this.setState({ activeODCal: this.props.activeODCal});
+    }
+    if (this.props.activePumpCal !== prevProps.activePumpCal) {
+      this.setState({activePumpCal: this.props.activePumpCal});
     }
     if (this.props.tempCalFiles !== prevProps.tempCalFiles) {
-      this.setState({ tempCalFiles: this.props.tempCalFiles})
+      this.setState({ tempCalFiles: this.props.tempCalFiles});
     }
     if (this.props.odCalFiles !== prevProps.odCalFiles) {
-      this.setState({ odCalFiles: this.props.odCalFiles})
+      this.setState({ odCalFiles: this.props.odCalFiles});
+    }
+    if (this.props.pumpCalFiles !== prevProps.pumpCalFiles) {
+      this.setState({pumpCalFiles: this.props.pumpCalFiles});
     }
     if (this.props.showRawOD !== prevProps.showRawOD) {
-      this.setState({ showRawOD: this.props.showRawOD})
+      this.setState({ showRawOD: this.props.showRawOD});
     }
     if (this.props.showRawTemp !== prevProps.showRawTemp) {
-      this.setState({ showRawTemp: this.props.showRawTemp})
+      this.setState({ showRawTemp: this.props.showRawTemp});
     }
   }
 
@@ -196,8 +212,10 @@ class SwipeableTextMobileStepper extends React.Component {
                       currentButtons={activeStep}
                       activeTempCal={this.state.activeTempCal}
                       activeODCal={this.state.activeODCal}
+                      activePumpCal={this.state.activePumpCal}
                       tempCalFiles= {this.state.tempCalFiles}
                       odCalFiles={this.state.odCalFiles}
+                      pumpCalFiles={this.state.pumpCalFiles}
                       showRawTemp= {this.state.showRawTemp}
                       showRawOD= {this.state.showRawOD}
                       currentTag={tutorialSteps[activeStep].outputTag}

--- a/app/components/setupButtons/CalibrationButtons.js
+++ b/app/components/setupButtons/CalibrationButtons.js
@@ -16,7 +16,7 @@ const materialStyles = {
     padding: '0px 0px 0px 25px',
   },
   labelText: {
-    padding: '8px 20px 0px 0px',
+    padding: '10px 20px 0px 0px',
     color: 'white',
     fontWeight: 'bold',
     fontSize: '20px',
@@ -34,8 +34,10 @@ class CalibrationButtons extends React.Component {
       open: false,
       activeTempCal: this.props.activeTempCal,
       activeODCal: this.props.activeODCal,
+      activePumpCal: this.props.activePumpCal,
       tempCalFiles: this.props.tempCalFiles,
       odCalFiles: this.props.odCalFiles,
+      pumpCalFiles: this.props.pumpCalFiles,
       modalFiles: [],
       modalParameter: '',
       showRawTemp: this.props.showRawTemp,
@@ -44,22 +46,28 @@ class CalibrationButtons extends React.Component {
   }
   componentDidUpdate(prevProps) {
     if (this.props.activeTempCal !== prevProps.activeTempCal) {
-      this.setState({ activeTempCal: this.props.activeTempCal})
+      this.setState({ activeTempCal: this.props.activeTempCal});
     }
     if (this.props.activeODCal !== prevProps.activeODCal) {
-      this.setState({ activeODCal: this.props.activeODCal})
+      this.setState({ activeODCal: this.props.activeODCal});
+    }
+    if (this.props.activePumpCal !== prevProps.activePumpCal) {
+      this.setState({activePumpCal: this.props.activePumpCal});
     }
     if (this.props.tempCalFiles !== prevProps.tempCalFiles) {
-      this.setState({ tempCalFiles: this.props.tempCalFiles})
+      this.setState({ tempCalFiles: this.props.tempCalFiles});
     }
     if (this.props.odCalFiles !== prevProps.odCalFiles) {
-      this.setState({ odCalFiles: this.props.odCalFiles})
+      this.setState({ odCalFiles: this.props.odCalFiles});
+    }
+    if (this.props.pumpCalFiles !== prevProps.pumpCalFiles) {
+      this.setState({pumpCalFiles: this.props.pumpCalFiles});
     }
     if (this.props.showRawOD !== prevProps.showRawOD) {
-      this.setState({ showRawOD: this.props.showRawOD})
+      this.setState({ showRawOD: this.props.showRawOD});
     }
     if (this.props.showRawTemp !== prevProps.showRawTemp) {
-      this.setState({ showRawTemp: this.props.showRawTemp})
+      this.setState({ showRawTemp: this.props.showRawTemp});
     }
   }
 
@@ -84,6 +92,14 @@ class CalibrationButtons extends React.Component {
       modalParameter: 'temp'
     });
   }
+  changeActivePumpCal = () => {
+    console.log(this.state.pumpCalFiles);
+    this.setState({
+      open: true,
+      modalFiles: this.state.pumpCalFiles,
+      modalParameter: 'pump'
+    });
+  }
 
   toggleRawTemp = () => {
     this.props.onSelectNewCal('rawtemp', []);
@@ -100,6 +116,9 @@ class CalibrationButtons extends React.Component {
     }
     else if (this.state.modalParameter == 'temp') {
       this.props.onSelectNewCal(this.state.modalParameter, [this.state.activeODCal, this.state.modalFiles[index]]);
+    }
+    else if (this.state.modalParameter == 'pump') {
+      this.props.onSelectNewCal(this.state.modalParameter, [this.state.activePumpCal, this.state.modalFiles[index]]);
     }
   }
 
@@ -132,6 +151,10 @@ class CalibrationButtons extends React.Component {
             <Typography variant="h5" className={classes.labelText}> OD: </Typography>
             <button className='calibrationBtns' onClick={this.changeActiveODCal}>{this.state.activeODCal}</button>
             <button className={odRawBtn} onClick={this.toggleRawOD}>RAW</button>
+          </div>
+          <div className='row centered'>
+            <Typography variant="h5" className={classes.labelText}> Pump: </Typography>
+            <button className='calibrationBtns' onClick={this.changeActivePumpCal}>{this.state.activePumpCal}</button>
           </div>
           {/*<div className='row centered'>
             <Typography variant="h5" className={classes.labelText}> Pump: </Typography>


### PR DESCRIPTION
# What? Why?
Adding the pump cal to the setup page so that an active calibration can be selected before running an experiment.

Changes proposed in this pull request:
- Pump cal in setup page button.
- Calibration files fetched also distinguish pump calibrations.

Part of #97 
# Checks
- [ ] Updated documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
<img width="1096" alt="Screen Shot 2021-01-22 at 10 29 01 AM" src="https://user-images.githubusercontent.com/10240498/105510635-de599b00-5c9c-11eb-88f1-a074bf5bb70d.png">
