### PR TITLE
hiding files in expt editor page

### DIFF
--- a/app/components/ScriptEditor.js
+++ b/app/components/ScriptEditor.js
@@ -22,6 +22,7 @@ const remote = require('electron').remote;
 const app = remote.app;
 
 var editorComponent;
+var filesToShow = ['eVOLVER.py', 'custom_script.py'];
 
 const styles = {
   cardRoot: {
@@ -107,7 +108,9 @@ class ScriptEditor extends React.Component {
       var timestamp = new Date(util.inspect(stats.mtime));
       var lastModified = moment(timestamp).valueOf();
       var lastModifiedString = moment(timestamp).fromNow();
-      filesData.push({filename: allFiles[i], modified: lastModified, modifiedString: lastModifiedString});
+      if (filesToShow.includes(allFiles[i])) {
+        filesData.push({filename: allFiles[i], modified: lastModified, modifiedString: lastModifiedString});
+      }
     }
     this.setState({exptDirFiles: filesData});
   };


### PR DESCRIPTION
# What? Why?
Limiting the number of files that are presented for editing on the expt editor page to minimize potential confusion.

Addresses #84 

Changes proposed in this pull request:
- have a list of files that are acceptable to be displayed
- only add files into the editor table if they are in the list.
