### PR TITLE
Reset data capability and stop/play changes

### DIFF
--- a/app/components/python-shell/ModalClone.js
+++ b/app/components/python-shell/ModalClone.js
@@ -40,6 +40,7 @@ class ModalClone extends React.Component {
 
   onCloseModal = () => {
     this.setState({open: false, value:''});
+    this.props.onAlertAnswer(false);
   };
 
   handleAnswer = () => {
@@ -66,7 +67,7 @@ class ModalClone extends React.Component {
              modal: styles.newExptModal,
              overlay: styles.customOverlay
            }}>
-           <div style={{height: '120px'}}>
+           <div style={{height: '180px'}}>
               <p style={{textAlign: 'center', margin: '20px 50px 15px 50px', fontStyle: 'italic', fontSize: '24px',fontWeight: 'bold'}}>
                 {this.state.question}
               </p>

--- a/app/components/python-shell/ModalReset.js
+++ b/app/components/python-shell/ModalReset.js
@@ -1,0 +1,85 @@
+// @flow
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { withStyles } from '@material-ui/core/styles';
+import Modal from 'react-responsive-modal';
+import styles from './modal-styling.css';
+
+
+
+const cardStyles = {
+
+};
+
+
+class ModalReset extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: this.props.resetOpen,
+      question: this.props.resetQuestion,
+      value: ''
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.resetOpen !== prevProps.resetOpen) {
+      this.setState({ open: this.props.resetOpen});
+    }
+    if (this.props.resetQuestion !== prevProps.resetQuestion) {
+      this.setState({question: this.props.resetQuestion});
+    }
+  }
+  
+  componentWillReceiveProps(nextProps) {
+      this.setState({open:nextProps.resetOpen, question: nextProps.resetQuestion});
+  }
+
+  onOpenModal = () => {
+    this.setState({ open: true, input:''});
+  };
+
+  onCloseModal = () => {
+    this.setState({open: false, value:''});
+    this.props.onResetAnswer(false);
+  };
+
+  handleAnswer = () => {
+    this.setState({open: false, value: ''});
+    this.props.onResetAnswer(true);
+  }
+
+  render() {
+    const { open } = this.state;
+    var buttons = this.props.ableToReset ? <div className='alertBtnRow' style={{height: 50, margin: '10px 0px 10px 0px'}}>
+              <button onClick={this.handleAnswer} className={styles.alertBtnsReset}>YES</button>
+              <button onClick={this.onCloseModal} className={styles.alertBtnsReset}>NO</button>
+            </div> : <div/>;
+
+    return (
+      <div>
+        <Modal
+          open={open}
+          onClose={this.onCloseModal}
+          onRequestClose={this.onCloseModal}
+          center
+          classNames={{
+             closeButton: styles.alertCloseButton,
+             modal: styles.resetExptModal,
+             overlay: styles.customOverlay
+           }}>
+           <div style={{height: '80px'}}>
+              <p style={{textAlign: 'center', margin: '0px 10px 0px 10px', fontStyle: 'italic', fontSize: '24px',fontWeight: 'bold'}}>
+                {this.state.question}
+              </p>
+            </div>
+            {buttons}
+          </Modal>
+      </div>
+
+    );
+  }
+}
+
+export default withStyles(cardStyles)(ModalReset);

--- a/app/components/python-shell/ScriptFinder.js
+++ b/app/components/python-shell/ScriptFinder.js
@@ -8,7 +8,7 @@ import parsePath from 'parse-filepath';
 import jsonQuery from 'json-query';
 import {MdCached} from 'react-icons/md';
 import ReactTable from "react-table";
-import {FaPlay, FaStop, FaPause, FaPen, FaChartBar } from 'react-icons/fa';
+import {FaPlay, FaStop, FaPen, FaChartBar } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import routes from '../../constants/routes.json';
 
@@ -122,10 +122,7 @@ class ScriptFinder extends React.Component {
   };
   
   getStatus = (expt) => {
-      if (this.props.pausedExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, expt))) {
-          return "Paused";
-      }
-      else if (this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, expt))) {
+      if (this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, expt))) {
           return "Running";
       }
       else {
@@ -154,17 +151,17 @@ class ScriptFinder extends React.Component {
       {
         Header: 'Name',
         accessor: 'key', // String-based value accessors!
-        width: 295
+        width: 280
       },
       {
         Header: 'Last Modified',
         accessor: 'modified',
         Cell: props => <span> {props.original.modifiedString} </span>,
-        width: 215
+        width: 205
       },
       {
           Header: 'Status',
-          width: 150,
+          width: 135,
           Cell: cellInfo => <span>{this.getStatus(cellInfo.row.key)}</span>
       },
       {
@@ -172,8 +169,8 @@ class ScriptFinder extends React.Component {
           Cell: (cellInfo) => (<div>
             <Link className="scriptFinderEditBtn" id="edits" to={{pathname: routes.EDITOR, exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key), evolverIp:this.props.evolverIp}}><button className="tableIconButton" onClick={() => this.props.onEdit(cellInfo.row.key)}> <FaPen size={13}/> </button></Link>
             <Link className="scriptFinderEditBtn" id="graphs" to={{pathname: routes.GRAPHING, exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)}}><button className="tableIconButton" onClick={() => this.props.onGraph(cellInfo.row.key)}> <FaChartBar size={18}/> </button></Link>
-            {this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)) && !this.props.pausedExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)) ? (<button className="tableIconButton" onClick={() => this.props.onPause(cellInfo.row.key)} disabled={this.props.disablePlay}> <FaPause size={13}/> </button>) : (<button className="tableIconButton" onClick={() => this.handlePlay(cellInfo.row.key)} disabled={this.props.disablePlay}> <FaPlay size={13}/> </button>)}
-            <button className="tableIconButton" onClick={() => this.props.onStop(cellInfo.row.key)}> <FaStop size={13}/> </button>
+            {this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)) ? <button className="tableIconButton" onClick={() => this.props.onStop(cellInfo.row.key)}> <FaStop size={13}/> </button> : (<button className="tableIconButton" onClick={() => this.handlePlay(cellInfo.row.key)} disabled={this.props.disablePlay}> <FaPlay size={13}/> </button>)}
+            <button className="tableTextButton" onClick={() => this.props.onReset(cellInfo.row.key, this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)))}> RESET </button>
             <button className="tableTextButton" onClick={() => this.props.onClone(cellInfo.row.key)}> CLONE </button>
            </div>),
           width: 400

--- a/app/components/python-shell/modal-styling.css
+++ b/app/components/python-shell/modal-styling.css
@@ -21,6 +21,16 @@
     text-align: center;
     border-radius: 5px;
     border-color: white;
+    border: 2px solid white;
+}
+
+.resetExptModal {
+    background-color: black;
+    width: 750px;
+    text-align: center;
+    border-radius: 5px;
+    border-color: white;
+    border: 2px solid white;
 }
 
 .alertCloseButton {
@@ -31,5 +41,9 @@
 }
 
 .alertBtns {
-    top: 30px;
+  top: 30px;
+}
+
+.alertBtnsReset {
+  margin-left: 15px;
 }

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -47,7 +47,6 @@ var available = [];
 var maxShells = 5;
 
 var exptMap = {};
-var pausedExpts = [];
 var activeIp = '';
 
 /* Generate browser window for an experiment */
@@ -81,7 +80,6 @@ function runPyshells() {
         }
     }
     mainWindow.webContents.send('running-expts', Object.keys(exptMap));
-    mainWindow.webContents.send('paused-expts', pausedExpts);
 }
 
 /* Get array of running experiments from exptMap. Store path and pid information only. */
@@ -147,47 +145,17 @@ ipcMain.on('send-message', (event, arg) => {
    recipientShell.send(arg[1], arg[2]);
 });
 
-ipcMain.on('pause-script', (event, arg) => {
-   var recipientShell = exptMap[arg].browser_contents;
-   recipientShell.send('pause-script');
-   pausedExpts.push(arg);
-   mainWindow.webContents.send('running-expts',Object.keys(exptMap));
-   mainWindow.webContents.send('paused-expts', pausedExpts);
-});
-
-ipcMain.on('continue-script', (event, arg) => {
-   var recipientShell = exptMap[arg].browser_contents;
-   recipientShell.send('continue-script');
-   for (var i = 0; i < pausedExpts.length; i++) {
-       if (pausedExpts[i] === arg) {
-           pausedExpts.splice(i, 1);
-       }
-   }
-   mainWindow.webContents.send('running-expts',Object.keys(exptMap));
-   mainWindow.webContents.send('paused-expts', pausedExpts);
-});
-
 ipcMain.on('stop-script', (event, arg) => {
    var recipientShell = exptMap[arg].browser_contents;
    recipientShell.send('stop-script');
    delete exptMap[arg];
    storeRunningExpts();
 
-   for (var i = 0; i < pausedExpts.length; i++) {
-       if (pausedExpts[i] === arg) {
-           pausedExpts.splice(i, 1);
-       }
-   }
    mainWindow.webContents.send('running-expts',Object.keys(exptMap));
-   mainWindow.webContents.send('paused-expts', pausedExpts);
 });
 
 ipcMain.on('running-expts', (event, arg) => {
    mainWindow.webContents.send('running-expts',Object.keys(exptMap));
-});
-
-ipcMain.on('paused-expts', (event, arg) => {
-   mainWindow.webContents.send('paused-expts', pausedExpts);
 });
 
 ipcMain.on('ready', (event, arg) => {


### PR DESCRIPTION
# What? Why?
Addresses #83. Adds a way to reset experiment data and changes play/stop/pause functionality. No more pause, only play and stop. Pause is functionally the same as stop.

Changes proposed in this pull request:
- Change play/stop/pause buttons
- Add a reset button
- add a modal to confirm data deletion before carrying it out.

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
<img width="1103" alt="Screen Shot 2021-02-01 at 8 15 58 PM" src="https://user-images.githubusercontent.com/10240498/106538655-958ab900-64ca-11eb-9ded-557892b87db7.png">

<img width="1106" alt="Screen Shot 2021-02-01 at 8 16 06 PM" src="https://user-images.githubusercontent.com/10240498/106538616-81df5280-64ca-11eb-860e-416d506ce3fc.png">
<img width="1106" alt="Screen Shot 2021-02-01 at 8 16 21 PM" src="https://user-images.githubusercontent.com/10240498/106538679-9de2f400-64ca-11eb-92e5-06b913419484.png">
<img width="1100" alt="Screen Shot 2021-02-01 at 8 54 48 PM" src="https://user-images.githubusercontent.com/10240498/106541295-ca4d3f00-64cf-11eb-94de-0b726c580a47.png">



