### PR TITLE
Background script alerts main thread on close

### DIFF
--- a/app/background.html
+++ b/app/background.html
@@ -77,8 +77,6 @@
 		var options = {
 			mode: 'text',
 			args: arg.flag
-			//pythonPath: '/Library/Frameworks/Python.framework/Versions/3.6/bin/python3',
-			//args: ['-z', arg['zero'], '-o', arg['overwrite'], '-c', arg['continue'], '-p', JSON.stringify(arg['parameters']), '-i', arg['evolver-ip'], '-t', arg['evolver-port'], '-n', arg['name'], '-b', arg['blank']]
 		};
 		pyShell = new PythonShell(scriptName, options);
 		console.log('starting expt');
@@ -88,6 +86,11 @@
 			logger.info(message);
 		});
 		var pid = pyShell.childProcess.pid;
+		pyShell.on('close', function() {
+			console.log('eVOLVER script with PID ' + pid + ' closed.');
+			ipcRenderer.send('close', pid);
+			ready();
+		});
 		ipcRenderer.send('store-pid', [arg.scriptDir, pid]);
 	});
 	ready();

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -156,8 +156,19 @@ ipcMain.on('stop-script', (event, arg) => {
    recipientShell.send('stop-script');
    delete exptMap[arg];
    storeRunningExpts();
-
    mainWindow.webContents.send('running-expts',Object.keys(exptMap));
+});
+
+ipcMain.on('close', (event, arg) => {
+  var exptMapKeys = Object.keys(exptMap);
+  for (var i = 0; i < exptMapKeys.length; i++) {
+    if (exptMap[exptMapKeys[i]].pid === arg) {
+      delete exptMap[exptMapKeys[i]];
+      storeRunningExpts();
+      mainWindow.webContents.send('running-expts', Object.keys(exptMap));
+      break;
+    }
+  }
 });
 
 ipcMain.on('running-expts', (event, arg) => {


### PR DESCRIPTION
# What? Why?
The background window was not telling the main thread when the evolver script was closed due to crashing or other errors. This would leave the status and experiment map in an incorrect state.

Address #117 

Changes proposed in this pull request:
- background pyshell object uses the close event and sends a message back to the main thread.
- main thread removes the experiment from the map on closure and updates the status

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
