### PR TITLE
Show all files toggle

### DIFF
--- a/app/components/ScriptEditor.css
+++ b/app/components/ScriptEditor.css
@@ -100,7 +100,7 @@
 }
 
 .editor-buttons .eb {
-  margin-right: 5px;
+  margin: 10px 0px 0px 10px;
   font-size: 15px;
 }
 
@@ -110,8 +110,10 @@
 
 .editor-buttons {
   position: absolute;
-  left: 5px;
-  top: 580px;
+  left: 45px;
+  top: 500px;
+  width: 400px;
+  overflow-y: auto;
 }
 
 .select-div {

--- a/app/components/ScriptEditor.js
+++ b/app/components/ScriptEditor.js
@@ -80,7 +80,10 @@ class ScriptEditor extends React.Component {
       newFileAlertDirections: "Enter the new filename",
       deleteFileAlertDirections: "",
       deleteFileAlertOpen: false,
-      selectedEditor:exptEditorOptions[0],    
+      selectedEditor:exptEditorOptions[0],
+      showAllFilesButtonTextOptions: ['Show All Files', 'Hide Files'],
+      showAllFilesButtonText: 'Show All Files',
+      showAllFiles: false
     };        
   }
 
@@ -108,7 +111,7 @@ class ScriptEditor extends React.Component {
       var timestamp = new Date(util.inspect(stats.mtime));
       var lastModified = moment(timestamp).valueOf();
       var lastModifiedString = moment(timestamp).fromNow();
-      if (filesToShow.includes(allFiles[i])) {
+      if ((filesToShow.includes(allFiles[i]) || this.state.showAllFiles) && !stats.isDirectory()) {
         filesData.push({filename: allFiles[i], modified: lastModified, modifiedString: lastModifiedString});
       }
     }
@@ -198,6 +201,12 @@ class ScriptEditor extends React.Component {
       console.log(vialData);
       var filehandle = fs.openSync(filename, 'w');      
       fs.writeSync(filehandle, JSON.stringify(vialData));
+  };
+
+  showAllFilesToggle = () => {
+    var showAllFiles = !this.state.showAllFiles;
+    var showAllFilesButtonText = showAllFiles ? this.state.showAllFilesButtonTextOptions[1] : this.state.showAllFilesButtonTextOptions[0];
+    this.setState({showAllFiles: showAllFiles, showAllFilesButtonText}, function () {this.loadTable();});
   }
 
   render() {
@@ -220,6 +229,7 @@ class ScriptEditor extends React.Component {
       <button class="eb" onClick={this.newfile}>New File</button>
       <button class="eb" onClick={this.deletefile}>Delete</button>
       <button class="eb" onClick={this.resetparams}>Reset Params</button>
+      <button class="eb" onClick={this.showAllFilesToggle}>{this.state.showAllFilesButtonText}</button>
     </div>;
 
     var selector = <div class="select-div">


### PR DESCRIPTION
# What? Why?
This gives the ability to view/edit all files within an experiment in the case that an advanced user wants to see or change things. Normally we only display `custom_script.py` and `eVOVLER.py` - other files do not need to be seen/edited usually.
Changes proposed in this pull request:
- A toggle button to show all/hide files in the script editor page.
- Button when pressed toggles what files are displayed in the table.

Addresses #84 

# Checks
- [ ] Updated documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
<img width="1099" alt="Screen Shot 2021-02-09 at 8 56 58 AM" src="https://user-images.githubusercontent.com/10240498/107373711-cf545480-6ab4-11eb-891a-1b3b933a60f6.png">
<img width="1100" alt="Screen Shot 2021-02-09 at 8 57 04 AM" src="https://user-images.githubusercontent.com/10240498/107373720-d1b6ae80-6ab4-11eb-8f53-f463dfe91358.png">

