### PR TITLE
Adding expt control and graph buttons to editor

### DIFF
--- a/app/components/ScriptEditor.css
+++ b/app/components/ScriptEditor.css
@@ -116,6 +116,14 @@
   overflow-y: auto;
 }
 
+.editor-control-buttons {
+  position: absolute;
+  left: 280px;
+  top: 579px;
+  width: 100px;
+  overflow-y: auto;
+}
+
 .select-div {
   position: absolute;
   left: 900px;


### PR DESCRIPTION
# What? Why?
Address #94 to enable starting/stopping expt and viewing data from the editor page.

Changes proposed in this pull request:
- Add a play/stop + graph button to the editor page

<img width="1102" alt="Screen Shot 2021-03-03 at 12 20 04 PM" src="https://user-images.githubusercontent.com/10240498/109845284-f668f680-7c1a-11eb-97a0-6949a5432716.png">
