### PR TITLE
Changing ymin for graphs

### DIFF
--- a/app/components/graphing/VialArrayGraph.js
+++ b/app/components/graphing/VialArrayGraph.js
@@ -124,7 +124,7 @@ class VialArrayGraph extends React.Component {
         var timePlotted = parseFloat(this.state.timePlotted.substring(0, this.state.timePlotted.length - 1));
 
         if (this.state.parameter == 'OD'){
-          ymin = 0;
+          ymin = -0.1;
           var odArray;
           try {
             odArray = fs.readFileSync(odPath).toString().split('\n');
@@ -183,7 +183,7 @@ class VialArrayGraph extends React.Component {
         var timePlotted = parseFloat(this.state.timePlotted.substring(0, this.state.timePlotted.length - 1));
 
         if (this.state.parameter == 'OD'){
-          ymin = 0;
+          ymin = -0.1;
           var odArray;
           try {
             odArray = fs.readFileSync(odPath).toString().split('\n');


### PR DESCRIPTION
# What? Why?

Addresses #133 to allow negative values to be displayed on the graphs. This is necessary as it is sometimes possible at the start of an experiment for the values to dip slightly negative due to noise

Changes proposed in this pull request:
- set `ymin` to `-.01` for the OD graphs
<img width="1104" alt="Screen Shot 2021-03-03 at 2 40 10 PM" src="https://user-images.githubusercontent.com/10240498/109862601-a005b300-7c2e-11eb-99cd-71ae1d3a29cb.png">
<img width="1103" alt="Screen Shot 2021-03-03 at 2 40 02 PM" src="https://user-images.githubusercontent.com/10240498/109862602-a09e4980-7c2e-11eb-9fd9-2758712464c8.png">
