### PR TITLE
Adding a new expt button and moving template on expt manager page

### DIFF
--- a/app/components/ExptManager.css
+++ b/app/components/ExptManager.css
@@ -13,6 +13,13 @@
   height: 40px;
 }
 
+.newExptButton {
+  position: absolute;
+  top: 500px;
+  left: 375px;
+  width: 300px;
+}
+
 .RunScript{
   position: absolute;
   align-items: center;
@@ -43,7 +50,6 @@
   background-color: black;
   border: none;
   color: #f58245;
-
 }
 
 

--- a/app/components/ExptManager.js
+++ b/app/components/ExptManager.js
@@ -77,10 +77,10 @@ class ExptManager extends React.Component {
       });
     if (!fs.existsSync(path.join(app.getPath('userData'), this.state.scriptDir))) {
       fs.mkdirSync(path.join(app.getPath('userData'), this.state.scriptDir));
-      fs.mkdirSync(path.join(app.getPath('userData'), this.state.scriptDir, 'template'));
-      var customScriptFile = fs.createWriteStream(path.join(app.getPath('userData'), this.state.scriptDir, 'template', 'custom_script.py'));
-      var evolverFile = fs.createWriteStream(path.join(app.getPath('userData'), this.state.scriptDir, 'template', 'eVOLVER.py'));
-      var nbstreamreaderFile = fs.createWriteStream(path.join(app.getPath('userData'), this.state.scriptDir, 'template', 'nbstreamreader.py'));
+      fs.mkdirSync(path.join(app.getPath('userData'), 'template'));
+      var customScriptFile = fs.createWriteStream(path.join(app.getPath('userData'), 'template', 'custom_script.py'));
+      var evolverFile = fs.createWriteStream(path.join(app.getPath('userData'), 'template', 'eVOLVER.py'));
+      var nbstreamreaderFile = fs.createWriteStream(path.join(app.getPath('userData'), 'template', 'nbstreamreader.py'));
       var customScriptRequest = http.get("https://raw.githubusercontent.com/FYNCH-BIO/dpu/rc/experiment/template/custom_script.py", function(response) {response.pipe(customScriptFile)});
       var evolverRequest = http.get("https://raw.githubusercontent.com/FYNCH-BIO/dpu/rc/experiment/template/eVOLVER.py", function(response) {response.pipe(evolverFile)});
       var nbstreamreaderRequest = http.get("https://raw.githubusercontent.com/FYNCH-BIO/dpu/rc/experiment/template/nbstreamreader.py", function(response) {response.pipe(nbstreamreaderFile)});
@@ -116,7 +116,7 @@ class ExptManager extends React.Component {
     };
 
     handleClone = (script) => {
-        this.setState({alertOpen: true, exptToClone: script});
+        this.setState({alertOpen: true});
     };
 
     handleReset = (script, running) => {
@@ -142,9 +142,9 @@ class ExptManager extends React.Component {
         }
     };
 
-    createNewExperiment = (exptName, exptToClone) => {
+    createNewExperiment = (exptName) => {
         var newDir = path.join(app.getPath('userData'), this.state.scriptDir, exptName);
-        var oldDir = path.join(app.getPath('userData'), this.state.scriptDir, exptToClone);
+        var oldDir = path.join(app.getPath('userData'), "template");
         if (!fs.existsSync(newDir)) {
             fs.mkdirSync(newDir);
         }
@@ -166,20 +166,18 @@ class ExptManager extends React.Component {
           <ScriptFinder subFolder={this.state.scriptDir}
             isScript= {true}
             onSelectFolder={this.handleSelectFolder}
-            onClone={this.handleClone}
             onEdit={this.handleEdit}
             onGraph={this.handleGraph}
             onStart={this.handleStart}
             onStop={this.handleStop}
-            onReset={this.handleReset}
             onContinue={this.handleContinue}
             runningExpts={this.state.runningExpts}
             refind={this.state.refind}
             evolverIp = {this.state.evolverIp}
             disablePlay = {this.state.disablePlay}/>
         </Card>
-
         <Link className="expManagerHomeBtn" id="experiments" to={routes.HOME}><FaArrowLeft/></Link>
+        <button className="newExptButton" onClick={this.handleClone}>New Experiment</button>
         <ModalClone
           alertOpen= {this.state.alertOpen}
           alertQuestion = {this.state.alertDirections}

--- a/app/components/python-shell/ScriptFinder.js
+++ b/app/components/python-shell/ScriptFinder.js
@@ -18,7 +18,6 @@ const app = remote.app;
 const styles = {
 };
 
-
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
@@ -94,11 +93,11 @@ class ScriptFinder extends React.Component {
       subFolder: this.props.subFolder,
       isScript: this.props.isScript,
     };
-    }
+  }
 
   componentDidMount(){
     var filequery = loadFileDir (this.state.subFolder, this.state.isScript);
-    var showPagination = (filequery.length > 5) 
+    var showPagination = (filequery.length > 5)
     this.setState({fileJSON: filequery, showPagination: showPagination});
   }
 
@@ -110,7 +109,7 @@ class ScriptFinder extends React.Component {
       })
     }
   }
-  
+
   componentWillReceiveProps(props) {
       const {refind} = this.props;
       if (props.refind !== refind) {
@@ -123,7 +122,7 @@ class ScriptFinder extends React.Component {
     var showPagination = (filequery.length > 5)
     this.setState({fileJSON: filequery, showPagination: showPagination})
   };
-  
+
   getStatus = (expt) => {
       if (this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, expt))) {
           return "Running";
@@ -133,7 +132,6 @@ class ScriptFinder extends React.Component {
       }
   }
 
-
   isSelected = rowInfo => {
     if (typeof rowInfo !== 'undefined'){
       if (rowInfo.index == this.state.selection) {
@@ -142,14 +140,14 @@ class ScriptFinder extends React.Component {
       }
     }
    };
-   
+
    handlePlay = exptName => {
        this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, exptName)) ? this.props.onContinue(exptName): this.props.onStart(exptName);
    }
-  
+
   render() {
     const { classes } = this.props;
-    const { fileJSON, dirLength } = this.state; 
+    const { fileJSON, dirLength } = this.state;
   var columns = [
       {
         Header: 'Name',
@@ -173,18 +171,16 @@ class ScriptFinder extends React.Component {
             <Link className="scriptFinderEditBtn" id="edits" to={{pathname: routes.EDITOR, exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key), evolverIp:this.props.evolverIp}}><button className="tableIconButton" onClick={() => this.props.onEdit(cellInfo.row.key)}> <FaPen size={13}/> </button></Link>
             <Link className="scriptFinderEditBtn" id="graphs" to={{pathname: routes.GRAPHING, exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)}}><button className="tableIconButton" onClick={() => this.props.onGraph(cellInfo.row.key)}> <FaChartBar size={18}/> </button></Link>
             {this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)) ? <button className="tableIconButton" onClick={() => this.props.onStop(cellInfo.row.key)}> <FaStop size={13}/> </button> : (<button className="tableIconButton" onClick={() => this.handlePlay(cellInfo.row.key)} disabled={this.props.disablePlay}> <FaPlay size={13}/> </button>)}
-            <button className="tableTextButton" onClick={() => this.props.onReset(cellInfo.row.key, this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)))}> RESET </button>
-            <button className="tableTextButton" onClick={() => this.props.onClone(cellInfo.row.key)}> CLONE </button>
            </div>),
           width: 400
-      }];    
+      }];
     return (
-                        
+
       <div>
         <ReactTable
           data={fileJSON}
           columns={columns}
-          noDataText="Select an Experiment Type"
+          noDataText="No Experiments Found"
           showPagination={this.state.showPagination}
           pageSize={8}
           height={100}


### PR DESCRIPTION
# What? Why?
Addresses #161 . The template should be read only and the experiment page should have a dedicated button for making a new experiment instead of cloning off the table.

Changes proposed in this pull request:
- Add a button underneath the expt manager table for making a new experiment.
- Removing the `clone` and `reset` buttons from the table
- moving the template experiment to a separate location
<img width="1102" alt="Screen Shot 2021-03-16 at 9 12 23 PM" src="https://user-images.githubusercontent.com/10240498/111400162-22fe2300-869d-11eb-913f-264fa3975b49.png">
