### PR TITLE
Add evolver column to expt manager table w/ selector on editor

### DIFF
--- a/app/components/ScriptEditor.css
+++ b/app/components/ScriptEditor.css
@@ -135,3 +135,9 @@
   height: 570px;
   width: 675px;
 }
+
+.editorEvolverSelect {
+  position: absolute;
+  left: 400px;
+  top: 15px;
+}

--- a/app/components/ScriptEditor.js
+++ b/app/components/ScriptEditor.js
@@ -11,7 +11,9 @@ import ReactTable from "react-table";
 import Select from 'react-select';
 import NewFileModal from './NewFileModal';
 import DeleteFileModal from './DeleteFileModal';
+import EvolverSelect from './evolverConfigs/EvolverSelect'
 const { ipcRenderer } = require('electron');
+const Store = require('electron-store');
 
 import 'brace/mode/python';
 import 'brace/theme/monokai';
@@ -21,6 +23,7 @@ var path = require('path');
 var util = require('util');
 const remote = require('electron').remote;
 const app = remote.app;
+const store = new Store();
 
 var editorComponent;
 var filesToShow = ['eVOLVER.py', 'custom_script.py'];
@@ -237,6 +240,12 @@ class ScriptEditor extends React.Component {
     console.log('to the plots');
   }
 
+  handleSelectEvolver = (evolver) => {
+    var evolverExptMap = store.get('evolverExptMap', {});
+    evolverExptMap[this.state.exptDir] = evolver.label;
+    store.set('evolverExptMap', evolverExptMap);
+  }
+
   render() {
     const { classes } = this.props;
     var columns = [
@@ -344,7 +353,9 @@ class ScriptEditor extends React.Component {
 
     return (
       <div>
-
+          <div className="editorEvolverSelect">
+            <EvolverSelect title="SELECT eVOLVER" onRef={function (ref) {}} selectEvolver = {this.handleSelectEvolver} selectedExperiment = {this.state.exptDir}/>
+          </div>
           <h2 className="editorTitle"> Experiment Editor: <span style={{color:"#f58245"}}>{this.state.exptName}</span></h2>
 
           {editorComponent}

--- a/app/components/evolverConfigs/EvolverSelect.js
+++ b/app/components/evolverConfigs/EvolverSelect.js
@@ -71,7 +71,8 @@ class EvolverSelect extends React.Component {
     super(props);
     this.state = {
       selectedOption: null,
-      registeredEvolvers: []
+      registeredEvolvers: [],
+      title: "ACTIVE EVOLVER"
     };
   }
 
@@ -81,16 +82,23 @@ class EvolverSelect extends React.Component {
     var scanTimer = setInterval(this.scanEvolvers, 1000);
     var selectedOption = this.state.selectedOption;
     var registeredEvolvers = this.state.registeredEvolvers;
+    var title = this.state.title;
     if (store.has('registeredEvolvers')){
-      selectedOption = store.get('activeEvolver')
-      registeredEvolvers = store.get('registeredEvolvers')
-      console.log(registeredEvolvers)
+      selectedOption = store.get('activeEvolver');
+      registeredEvolvers = store.get('registeredEvolvers');
+      console.log(registeredEvolvers);
+    }
+    if (store.has('evolverExptMap') && this.props.selectedExperiment) {
+      selectedOption = registeredEvolvers.filter(evo => evo.label === store.get('evolverExptMap')[this.props.selectedExperiment]);
+    }
+    if (this.props.title !== undefined) {
+      title = this.props.title;
     }
     this.setState({
       scanTimer: scanTimer,
       selectedOption: selectedOption,
-      registeredEvolvers: registeredEvolvers},
-      console.log(registeredEvolvers));
+      registeredEvolvers: registeredEvolvers,
+      title: title})
   }
 
   componentWillUnmount() {
@@ -162,7 +170,7 @@ class EvolverSelect extends React.Component {
             placeholder={<div>Select Registered Devices</div>}
           />
           <div style={{position:'absolute',right:'26px',top:'-10px'}}>
-            <Typography className={classes.title}> ACTIVE EVOLVER </Typography>
+            <Typography className={classes.title}> {this.state.title} </Typography>
           </div>
       </div>
 

--- a/app/components/python-shell/ScriptFinder.js
+++ b/app/components/python-shell/ScriptFinder.js
@@ -13,7 +13,10 @@ import { Link } from 'react-router-dom';
 import routes from '../../constants/routes.json';
 
 const remote = require('electron').remote;
+const Store = require('electron-store');
+
 const app = remote.app;
+const store = new Store();
 
 const styles = {
 };
@@ -124,6 +127,12 @@ loadFileDir = (subFolder, isScript) => {
     this.setState({fileJSON: filequery, showPagination: showPagination})
   };
 
+  getEvolver = (expt) => {
+    var evolverExptMap = store.get('evolverExptMap', {});
+    var evolver = evolverExptMap[path.join(app.getPath('userData'), this.props.subFolder, expt)] === undefined ? 'Not run yet' : evolverExptMap[path.join(app.getPath('userData'), this.props.subFolder, expt)];
+    return evolver;
+  };
+
   isSelected = rowInfo => {
     if (typeof rowInfo !== 'undefined'){
       if (rowInfo.index == this.state.selection) {
@@ -147,7 +156,7 @@ loadFileDir = (subFolder, isScript) => {
       {
         Header: 'Name',
         accessor: 'key', // String-based value accessors!
-        width: 280
+        width: 250
       },
       {
         Header: 'Last Run',
@@ -157,8 +166,14 @@ loadFileDir = (subFolder, isScript) => {
       },
       {
           Header: 'Status',
-          width: 135,
-          accessor: 'status'
+          accessor: 'status',
+          width: 125,
+      },
+      {
+        Header: 'eVOLVER',
+        accessor: 'evolver',
+        width: 270,
+        Cell: cellInfo => <span style={{fontSize: 20}}>{this.getEvolver(cellInfo.row.key)}</span>,
       },
       {
           Header: '',


### PR DESCRIPTION
# What? Why?
Addresses #156. The expt manager table needs to display the evolver that an experiment is being run on. Also, the eVOLVER should be selectable within the editor page.
Changes proposed in this pull request:
- Adding a column to the table with the selected eVOLVER
- Adding a selector to the editor page to pick an evolver
- Modify the constructor of the `EvolverSelect` component to allow customization of text and source for default value.
- Styling to accommodate the changes
<img width="1103" alt="Screen Shot 2021-03-24 at 9 20 28 AM" src="https://user-images.githubusercontent.com/10240498/112317238-37848180-8c82-11eb-8e19-05f8bd218197.png">
<img width="1108" alt="Screen Shot 2021-03-24 at 9 20 35 AM" src="https://user-images.githubusercontent.com/10240498/112317240-381d1800-8c82-11eb-82a8-172eaa0b0627.png">
