### PR TITLE
Update README with yarn installation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Setup
 
-Before running, setup up cron or other job scheduler to call `experiment_check.sh` bash script every 30 seconds to ensure that running experiments are not unintentionally lost. In addition, edit `config.sh` to include the path to `runningExpts.txt` before running `experiment_check.sh`
+This application uses the yarn package manager. Visit https://classic.yarnpkg.com/en/docs/install#debian-stable for additional information on installing yarn on your computer. The documentation also includes OS specific installation instructions under 'Alternatives'. Note that development of this application was done using Yarn 1 and not Yarn 2.  
 
 ## Install
 


### PR DESCRIPTION
README lacked information regarding Yarn installation and notice that users should use Yarn 1

Addresses #128 
Changes proposed in this pull request:
- Update README with warning to use Yarn 1 and link to official documentation for OS specific installation 

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
