### PR TITLE
Fix width of react table to prevent scrollbar

### DIFF
--- a/app/components/ExptManager.css
+++ b/app/components/ExptManager.css
@@ -69,7 +69,6 @@
 .ReactTable {
   position: absolute;
   left: -5px;
-  width: 1050px;
   color: white;
 }
 


### PR DESCRIPTION
# What? Why?
Addresses #177 Removes the scrollbar that would appear under the expt manager.

Changes proposed in this pull request:
- Remove the `width` styling in the css.