### PR TITLE
Fixing functionality/styling on expteditor buttons

### DIFF
--- a/app/components/DeleteExptModal.js
+++ b/app/components/DeleteExptModal.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core/styles';
 import Modal from 'react-responsive-modal';
 import styles from './modal-styling.css';
+import routes from '../constants/routes.json';
 
 
 
@@ -13,7 +14,7 @@ const cardStyles = {
 };
 
 
-class DeleteFileModal extends React.Component {
+class DeleteExptModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -69,11 +70,11 @@ class DeleteFileModal extends React.Component {
               </p>
               <div className='alertBtnRow' style={{margin: '0px 30px 0px 30px'}}>
               </div>
-              <button
-              onClick={this.handleAnswer}
+              <Link className="cloneButton" id="clone" to={{pathname: routes.EXPTMANAGER}}><button
+              onClick={() => this.handleAnswer()}
               className={styles.alertBtns}>
               Delete
-              </button> 
+              </button></Link>
               <button onClick={this.onCloseModal} className={styles.alertBtns}>Cancel</button>          
             </div>
           </Modal>
@@ -83,4 +84,4 @@ class DeleteFileModal extends React.Component {
   }
 }
 
-export default withStyles(cardStyles)(DeleteFileModal);
+export default withStyles(cardStyles)(DeleteExptModal);

--- a/app/components/ScriptEditor.css
+++ b/app/components/ScriptEditor.css
@@ -12,9 +12,10 @@
 
 .editorTitle {
   position: absolute;
-  top: 15px;
-  left: 90px;
+  top: 19px;
+  left: 80px;
   z-index: 10;
+  font-size: 25px;
 }
 
 .expEditorHomeBtn {
@@ -99,20 +100,25 @@
   color: black;
 }
 
-.editor-buttons .eb {
-  margin: 10px 0px 0px 10px;
+.ebfe {
+  width: 60px;
+  height: 50px;
+}
+
+.editor-buttons .ebfe {
+  margin: 5px 5px 5px 5px;
   font-size: 15px;
 }
 
-.editor-buttons .eb:active {
+.editor-buttons .ebfe:active {
   background: grey;
 }
 
 .editor-buttons {
   position: absolute;
-  left: 45px;
-  top: 500px;
-  width: 400px;
+  left: 5px;
+  top: 565px;
+  overflow: auto;
   overflow-y: auto;
 }
 

--- a/app/components/python-shell/ModalClone.js
+++ b/app/components/python-shell/ModalClone.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core/styles';
 import Modal from 'react-responsive-modal';
 import styles from './modal-styling.css';
+import routes from '../../constants/routes.json';
 
 
 
@@ -29,7 +30,7 @@ class ModalClone extends React.Component {
       this.setState({ open: this.props.alertOpen})
     }
   }
-  
+
   componentWillReceiveProps(nextProps) {
       this.setState({open:nextProps.alertOpen});
   }
@@ -47,7 +48,7 @@ class ModalClone extends React.Component {
     this.props.onAlertAnswer(this.state.value);
     this.setState({open: false, value: ''});
   }
-  
+
   handleChange = (event) => {
       this.setState({value: event.target.value});
   }
@@ -72,7 +73,7 @@ class ModalClone extends React.Component {
                 {this.state.question}
               </p>
               <div className='alertBtnRow' style={{margin: '0px 30px 0px 30px'}}>
-                  <input                    
+                  <input
                     className={styles.alertInput}
                     type="text"
                     value={this.state.value}
@@ -80,11 +81,11 @@ class ModalClone extends React.Component {
                     id="cloneAlertExperimentInput">
                   </input>
               </div>
-              <button
-              onClick={this.handleAnswer}
+              <Link className="cloneButton" id="clone" to={{pathname: routes.EXPTMANAGER}}><button
+              onClick={() => this.handleAnswer()}
               className={styles.alertBtns}>
               Submit
-              </button>              
+              </button></Link>
             </div>
           </Modal>
       </div>

--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
     "react-select": "^2.4.0",
     "react-selectable-fast": "^2.1.1",
     "react-simple-keyboard": "1.15.2",
+    "react-tooltip": "4.2.17",
     "react-swipeable-views": "^0.13.0",
     "react-swipeable-views-utils": "^0.13.0",
     "react-table": "^6.9.2",


### PR DESCRIPTION
# What? Why?
Addresses #158 
Changes proposed in this pull request:
Add a button to delete experiment: delete the entire directory and navigate back to the experiment editor page. Have a modal to confirm delete operation.
Add a button to clone experiment - use same button as the graphing page. Have a modal for setting a new name. Use the same modal as new experiment on the manager page.
Remove the New File and Reset Params buttons.
Add a button to open a finder/file explorer window at the location of the experiment (make sure OS independent)
Buttons should also appear on the t-stat GUI.

<img width="1107" alt="Screen Shot 2021-04-13 at 12 24 21 PM" src="https://user-images.githubusercontent.com/10240498/114587547-c66a3580-9c53-11eb-8b39-a661b34cb074.png">
<img width="1104" alt="Screen Shot 2021-04-13 at 12 25 03 PM" src="https://user-images.githubusercontent.com/10240498/114587548-c66a3580-9c53-11eb-98d8-ff177cb1427e.png">
<img width="1303" alt="Screen Shot 2021-04-13 at 12 24 51 PM" src="https://user-images.githubusercontent.com/10240498/114587549-c702cc00-9c53-11eb-898c-7ae87eeea918.png">
<img width="1106" alt="Screen Shot 2021-04-13 at 12 24 39 PM" src="https://user-images.githubusercontent.com/10240498/114587550-c702cc00-9c53-11eb-8390-4fbe13cd7392.png">
