### PR TITLE
fix month

### DIFF
--- a/app/components/python-shell/ScriptFinder.js
+++ b/app/components/python-shell/ScriptFinder.js
@@ -40,8 +40,8 @@ moment.updateLocale('en', {
         dd: "%d d",
         w:  "a w",
         ww: "%d w",
-        M:  "a m",
-        MM: "%d m",
+        M:  "a month",
+        MM: "%d month",
         y:  "a y",
         yy: "%d y"
     }


### PR DESCRIPTION
# What? Why?
Month and minute abbreviations looked the same.
Changes proposed in this pull request:
- Month should say `month` instead of `m`
<img width="405" alt="Screen Shot 2021-04-13 at 5 24 55 PM" src="https://user-images.githubusercontent.com/10240498/114623378-2fb26e80-9c7d-11eb-8090-c88346848809.png">
