### PR TITLE
Tstat default and file saving logic

### DIFF
--- a/app/components/DeleteExptModal.js
+++ b/app/components/DeleteExptModal.js
@@ -21,6 +21,7 @@ class DeleteExptModal extends React.Component {
       open: this.props.alertOpen,
       question: this.props.alertQuestion,
       answers: this.props.alertAnswers,
+      buttonText: this.props.buttonText,
       value: ''
     };
   }

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "json-query": "^2.2.2",
     "lodash.clonedeep": "^4.5.0",
     "log4js": "^4.0.2",
+    "md5-file": "5.0.0",
     "moment": "^2.24.0",
     "parse-filepath": "^1.0.2",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
# What? Why?
Addresses #172, #173, #174, and #188. Also implements logic to warn users about saving a file and disables the GUI if they do. Also checks if the files were ever modified from the template.
Changes proposed in this pull request:
- Modify the `DeleteFileModal` to be used modularly for saving / deleting
- Remove c stat from the dropdown
- Disable the dropdown if a file is ever saved
- File saving adds the expt to the store for persistance.
- Modal warning users before saving the file that they will no longer be able to use the GUI
- Note on the left of the file editor telling users they don't need to use this (for new users)

# Any screenshots or GIFs?
