### PR TITLE
Fixing heights/styling on manager page

### DIFF
--- a/app/components/ExptManager.css
+++ b/app/components/ExptManager.css
@@ -15,8 +15,8 @@
 
 .newExptButton {
   position: absolute;
-  top: 500px;
-  left: 375px;
+  top: 550px;
+  left: 397px;
   width: 300px;
 }
 

--- a/app/components/ExptManager.js
+++ b/app/components/ExptManager.js
@@ -35,10 +35,6 @@ const styles = {
     top: '60px',
     left: '75px',
     overflowY: 'auto'
-  },
-  cardPyshell: {
-    top: '200px',
-    left: '30px',
   }
 };
 

--- a/app/components/python-shell/ScriptFinder.js
+++ b/app/components/python-shell/ScriptFinder.js
@@ -218,7 +218,7 @@ loadFileDir = (subFolder, isScript) => {
           columns={columns}
           noDataText="No Experiments Found"
           showPagination={this.state.showPagination}
-          pageSize={8}
+          pageSize={7}
           height={100}
           resizable={false}
           showPageSizeOptions= {false}


### PR DESCRIPTION
# What? Why?
Fixing the styling - the pagination went over onto the new expt button.
<img width="1098" alt="Screen Shot 2021-04-16 at 7 38 34 AM" src="https://user-images.githubusercontent.com/10240498/115019223-e33a7f00-9e86-11eb-8f0a-98a12e35085c.png">

