### PR TITLE
Fix evolver sorting

### DIFF
--- a/app/components/python-shell/ScriptFinder.js
+++ b/app/components/python-shell/ScriptFinder.js
@@ -134,6 +134,7 @@ loadFileDir = (subFolder, isScript) => {
           resultJSON['data'][i]['fullPath'] = path.join(subFolder, resultJSON['data'][i]['key']);
           resultJSON['data'][i]['status'] = this.props.runningExpts.includes(path.join(app.getPath('userData'), 'experiments', resultJSON['data'][i].key)) ? 'Running' : 'Stopped';
           resultJSON['data'][i]['statusDot'] = this.props.runningExpts.includes(path.join(app.getPath('userData'), 'experiments', resultJSON['data'][i].key)) ? <Circle bgColor='#32CD32'/> : <Circle bgColor='#DC143C'/>;
+          resultJSON['data'][i]['evolver'] = this.getEvolver(resultJSON['data'][i]['key']);
 
         }
       }


### PR DESCRIPTION
# What? Why?
Evolver column wasn't indexed for sorting - the data wasn't added into that column at the time of loading table.
Changes proposed in this pull request:
- add evolver data into table info.
