### PR TITLE
Fixing styling on editor page - aligning

### DIFF
--- a/app/components/ScriptEditor.css
+++ b/app/components/ScriptEditor.css
@@ -49,8 +49,8 @@
 
 .ReactTable.ft {
   position: absolute;
-  left: -5px;
-  width: 400px;
+  left: 5px;
+  width: 600px;
   color: white;
 }
 
@@ -116,7 +116,7 @@
 
 .editor-buttons {
   position: absolute;
-  left: 5px;
+  left: 53px;
   top: 565px;
   overflow: auto;
   overflow-y: auto;

--- a/app/components/ScriptEditor.js
+++ b/app/components/ScriptEditor.js
@@ -43,7 +43,7 @@ const styles = {
   },
   cardEditor:{
     top: '63px',
-    left: '430px',
+    left: '520px',
     overflowY: 'auto'
   },
   cardFiles: {
@@ -327,12 +327,12 @@ class ScriptEditor extends React.Component {
       {
         Header: "File",
         accessor: "filename",
-        width: 250
+        width: 325
       },
       {
         Header: "Last Modified",
         accessor: "modifiedString",
-        width: 200
+        width: 150
       }
     ];
 
@@ -399,7 +399,7 @@ class ScriptEditor extends React.Component {
                 }
               }}
            />
-           <p style={{position: 'absolute', left: '5px', top: '200px', width: '375px', textAlign: 'center'}}>NOTE: If you are running a t-stat or other pre-defined module, you do not need to modify these files!</p>
+           <p style={{position: 'absolute', left: '53px', top: '250px', width: '375px', textAlign: 'center'}}>NOTE: If you are running a t-stat or other pre-defined module, you do not need to modify these files!</p>
 
       </div>
 
@@ -408,7 +408,7 @@ class ScriptEditor extends React.Component {
       editorComponent = <div><Card classes={{root:classes.cardRoot}} className={classes.cardEditor}>
             <AceEditor
               value={this.state.scriptContent}
-              width='675px'
+              width='585px'
               height='570px'
               mode="python"
               theme="monokai"


### PR DESCRIPTION
# What? Why?
The t-stat to file editor transition looked weird because the buttons weren't aligned and the editors weren't sized up correctly. Lots of tweaks to get it to look better.

Changes proposed in this pull request:
- Aligned the editors
- moved the buttons
- resized the file selector table.
<img width="1107" alt="Screen Shot 2021-04-16 at 8 28 59 AM" src="https://user-images.githubusercontent.com/10240498/115024249-d2d9d280-9e8d-11eb-8384-55a2485359c5.png">
<img width="1102" alt="Screen Shot 2021-04-16 at 8 28 52 AM" src="https://user-images.githubusercontent.com/10240498/115024251-d3726900-9e8d-11eb-980b-8da23e6a762a.png">
