### PR TITLE
Clicking names on table + fixing save button

### DIFF
--- a/app/components/DeleteExptModal.js
+++ b/app/components/DeleteExptModal.js
@@ -21,6 +21,7 @@ class DeleteExptModal extends React.Component {
       open: this.props.alertOpen,
       question: this.props.alertQuestion,
       answers: this.props.alertAnswers,
+      useLink: this.props.useLink,
       buttonText: this.props.buttonText,
       value: ''
     };
@@ -31,7 +32,7 @@ class DeleteExptModal extends React.Component {
       this.setState({ open: this.props.alertOpen, question: this.props.alertQuestion})
     }
   }
-  
+
   componentWillReceiveProps(nextProps) {
       this.setState({open:nextProps.alertOpen, question: this.props.alertQuestion});
   }
@@ -52,6 +53,17 @@ class DeleteExptModal extends React.Component {
 
   render() {
     const { open } = this.state;
+    var confirmButton;
+    if (this.state.useLink) {
+      confirmButton = <Link className="cloneButton" id="clone" to={{pathname: routes.EXPTMANAGER}}><button
+              onClick={() => this.handleAnswer()}
+              className={styles.alertBtns}>
+              {this.state.buttonText}
+              </button></Link>
+    }
+    else {
+      confirmButton = <button onClick={() => this.handleAnswer()} className={styles.alertBtns}>{this.state.buttonText}</button>;
+    }
 
     return (
       <div>
@@ -70,13 +82,9 @@ class DeleteExptModal extends React.Component {
                 {this.state.question}
               </p>
               <div className='alertBtnRow' style={{margin: '0px 30px 0px 30px'}}>
+              {confirmButton}
+              <button onClick={this.onCloseModal} className={styles.alertBtns}>Cancel</button>
               </div>
-              <Link className="cloneButton" id="clone" to={{pathname: routes.EXPTMANAGER}}><button
-              onClick={() => this.handleAnswer()}
-              className={styles.alertBtns}>
-              Delete
-              </button></Link>
-              <button onClick={this.onCloseModal} className={styles.alertBtns}>Cancel</button>          
             </div>
           </Modal>
       </div>

--- a/app/components/ScriptEditor.js
+++ b/app/components/ScriptEditor.js
@@ -215,7 +215,6 @@ class ScriptEditor extends React.Component {
     }
     store.set('editedExpts', editedExpts);
     this.setState({option: 1});
-    console.log(store.get('editedExpts', {}));
   };
 
   newfile = () => {
@@ -224,7 +223,9 @@ class ScriptEditor extends React.Component {
   };
 
   deleteexpt = () => {
-    console.log('deleting this shit'  )
+    var editedExpts = store.get('editedExpts', {});
+    delete editedExpts[this.state.exptName];
+    store.set('editedExpts', editedExpts)
     var directions = "Are you sure you want to delete the experiment " + this.state.exptName + "?";
     this.setState({deleteExptAlertDirections: directions}, function() {
       this.setState({deleteExptAlertOpen: true});
@@ -305,6 +306,7 @@ class ScriptEditor extends React.Component {
   handleSelectEvolver = (evolver) => {
     var evolverExptMap = store.get('evolverExptMap', {});
     evolverExptMap[this.state.exptDir] = evolver.label;
+    store.set('evolverExptMap', evolverExptMap)
   }
 
   render() {
@@ -439,8 +441,17 @@ class ScriptEditor extends React.Component {
             alertQuestion = {this.state.cloneExptAlertDirections}
             onAlertAnswer = {this.cloneExptAlertAnswer} />
           <DeleteExptModal
+            alertOpen = {this.state.saveFileAlertOpen}
+            alertQuestion = {this.state.saveFileAlertDirections}
+            buttonText = "Save File"
+            useLink = {false}
+            onAlertAnswer = {this.saveFileAlertAnswer}
+          />
+          <DeleteExptModal
             alertOpen = {this.state.deleteExptAlertOpen}
             alertQuestion = {this.state.deleteExptAlertDirections}
+            buttonText = "Delete"
+            useLink = {true}
             onAlertAnswer = {this.deleteExptAlertAnswer} />
 
         <Link className="expEditorHomeBtn" id="experiments" to={routes.EXPTMANAGER}><FaArrowLeft/></Link>

--- a/app/components/python-shell/ScriptFinder.js
+++ b/app/components/python-shell/ScriptFinder.js
@@ -82,6 +82,7 @@ class ScriptFinder extends React.Component {
       selection: 'undefined',
       subFolder: this.props.subFolder,
       isScript: this.props.isScript,
+      hoveredRow: null
     };
   }
 
@@ -130,6 +131,9 @@ loadFileDir = (subFolder, isScript) => {
             modified = moment(d).valueOf();
           }
           resultJSON['data'][i]['modified'] = modified;
+          if (modifiedString === undefined) {
+            modifiedString = 'Not run yet';
+          }
           resultJSON['data'][i]['modifiedString'] = modifiedString;
           resultJSON['data'][i]['fullPath'] = path.join(subFolder, resultJSON['data'][i]['key']);
           resultJSON['data'][i]['status'] = this.props.runningExpts.includes(path.join(app.getPath('userData'), 'experiments', resultJSON['data'][i].key)) ? 'Running' : 'Stopped';
@@ -171,6 +175,13 @@ loadFileDir = (subFolder, isScript) => {
        this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, exptName)) ? this.props.onContinue(exptName): this.props.onStart(exptName);
    }
 
+   getPathname = exptName => {
+      if (this.props.runningExpts.includes(path.join(app.getPath('userData'), this.props.subFolder, exptName))) {
+        return routes.GRAPHING;
+      }
+      return routes.EDITOR;
+   }
+
   render() {
     const { classes } = this.props;
     const { fileJSON, dirLength } = this.state;
@@ -182,25 +193,26 @@ loadFileDir = (subFolder, isScript) => {
       {
         Header: 'Name',
         accessor: 'key', // String-based value accessors!
-        width: 400
+        width: 400,
+        Cell: cellInfo => <Link className="scriptFinderEditBtn" id="table" to={{pathname: this.getPathname(cellInfo.row.key), exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)}}><div style={{width: '650px'}}>{cellInfo.row.key}</div></Link>
       },
       {
         Header: 'Last Run',
         accessor: 'modified',
-        Cell: props => <span> {props.original.modifiedString} </span>,
+        Cell: cellInfo => <Link className="scriptFinderEditBtn" id="table" to={{pathname: this.getPathname(cellInfo.row.key), exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)}}><span> {cellInfo.original.modifiedString} </span></Link>,
         width: 120
       },
       {
           Header: 'Status',
           accessor: 'status',
           width: 90,
-          Cell: props => <div>{props.original.statusDot}</div>
+          Cell: cellInfo => <Link className="scriptFinderEditBtn" id="table" to={{pathname: this.getPathname(cellInfo.row.key), exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)}}><div>{cellInfo.original.statusDot}</div></Link>
       },
       {
         Header: 'eVOLVER',
         accessor: 'evolver',
         width: 250,
-        Cell: cellInfo => <span style={{fontSize: 20}}>{this.getEvolver(cellInfo.row.key)}</span>,
+        Cell: cellInfo => <Link className="scriptFinderEditBtn" id="table" to={{pathname: this.getPathname(cellInfo.row.key), exptDir: path.join(app.getPath('userData'), this.props.subFolder, cellInfo.row.key)}}><span style={{fontSize: 20}}>{this.getEvolver(cellInfo.row.key)}</span></Link>,
       },
       {
           Header: '',
@@ -231,6 +243,7 @@ loadFileDir = (subFolder, isScript) => {
               onClick: (e, handleOriginal) => {
                 this.setState({selection: rowInfo.index})
                 if (handleOriginal) {
+                  console.log('handling original')
                   handleOriginal()
                 }
               },


### PR DESCRIPTION
# What? Why?
Allow name clicking on the exptmanager table to navigate to the editor/graphing page dependent on expt status. Fix the buttons on the editor that got broken from merge conflict resolution