### PR TITLE
Change expt name

### DIFF
--- a/app/components/ScriptEditor.css
+++ b/app/components/ScriptEditor.css
@@ -147,3 +147,12 @@
   left: 400px;
   top: 15px;
 }
+
+.edit-expt-name-btn {
+  position: absolute;
+  left: 390px;
+  top: -5px;
+  border: none;
+  width: 50px;
+  background-color: #000000;
+}

--- a/app/components/python-shell/ModalClone.js
+++ b/app/components/python-shell/ModalClone.js
@@ -21,7 +21,8 @@ class ModalClone extends React.Component {
       open: this.props.alertOpen,
       question: this.props.alertQuestion,
       answers: this.props.alertAnswers,
-      value: ''
+      value: '',
+      stayOnPage: this.props.stayOnPage
     };
   }
 
@@ -56,6 +57,22 @@ class ModalClone extends React.Component {
   render() {
     const { open } = this.state;
 
+    var submitButton;
+    if (this.state.stayOnPage) {
+      submitButton = <button
+        onClick={() => this.handleAnswer()}
+        className={styles.alertBtns}>
+        Submit
+      </button>
+    }
+    else {
+      submitButton = <Link className="cloneButton" id="clone" to={{pathname: routes.EXPTMANAGER}}><button
+        onClick={() => this.handleAnswer()}
+        className={styles.alertBtns}>
+        Submit
+      </button></Link>
+    }
+
     return (
       <div>
         <Modal
@@ -81,15 +98,10 @@ class ModalClone extends React.Component {
                     id="cloneAlertExperimentInput">
                   </input>
               </div>
-              <Link className="cloneButton" id="clone" to={{pathname: routes.EXPTMANAGER}}><button
-              onClick={() => this.handleAnswer()}
-              className={styles.alertBtns}>
-              Submit
-              </button></Link>
+              {submitButton}
             </div>
           </Modal>
       </div>
-
     );
   }
 }


### PR DESCRIPTION
# What? Why?

Addresses #184. Allow the experiment name to be changed.

Changes proposed in this pull request:
- Button next to the expt name on the editor that pops up a modal
- Change the styling of how the experiment name is displayed
- add `...` if the experiment name is too long

# Any screenshots or GIFs?
<img width="521" alt="Screen Shot 2021-05-18 at 8 04 40 PM" src="https://user-images.githubusercontent.com/10240498/118738169-66e3e480-b814-11eb-9038-0f4801893407.png">
<img width="1105" alt="Screen Shot 2021-05-18 at 7 57 23 PM" src="https://user-images.githubusercontent.com/10240498/118738170-677c7b00-b814-11eb-8b58-ee205e8ec8f4.png">
