### PR TITLE
Adding buttons for expt control to graphs

### DIFF
--- a/app/components/DeleteExptModal.js
+++ b/app/components/DeleteExptModal.js
@@ -23,7 +23,7 @@ class DeleteExptModal extends React.Component {
       answers: this.props.alertAnswers,
       useLink: this.props.useLink,
       buttonText: this.props.buttonText,
-      value: ''
+      value: this.props.value
     };
   }
 
@@ -46,8 +46,8 @@ class DeleteExptModal extends React.Component {
     this.setState({open: false, value:''});
   };
 
-  handleAnswer = () => {
-    this.props.onAlertAnswer(1);
+  handleAnswer = (value) => {
+    this.props.onAlertAnswer(1, value);
     this.setState({open: false, value: ''});
   }
 
@@ -62,7 +62,7 @@ class DeleteExptModal extends React.Component {
               </button></Link>
     }
     else {
-      confirmButton = <button onClick={() => this.handleAnswer()} className={styles.alertBtns}>{this.state.buttonText}</button>;
+      confirmButton = <button onClick={() => this.handleAnswer(this.state.value)} className={styles.alertBtns}>{this.state.buttonText}</button>;
     }
 
     return (

--- a/app/components/Graph.css
+++ b/app/components/Graph.css
@@ -31,7 +31,7 @@
   background-color: black;
   border: 1px solid white;
   position: absolute;
-  top: 392px;
+  top: 332px;
   left: 27px;
   color: orange;
   font-size: 17px;
@@ -54,13 +54,13 @@
 .dataActionButtons {
   position: absolute;
   top: 550px;
-  left: 20px;
-  width: 400px;
+  left: 10px;
+  width: 330px;
   overflow-y: auto;
 }
 
 .dataActionButton {
-  width: 150px;
+  width: 130px;
   margin: 0px 10px 0px 0px;
 }
 
@@ -72,4 +72,22 @@
   position: absolute;
   top: 10px;
   left: 350px;
+}
+
+.expt-buttons-graph .ebfe {
+  margin: 5px 5px 5px 5px;
+  font-size: 15px;
+}
+
+.expt-buttons-graph .ebfe:active {
+  background: grey;
+}
+
+.expt-buttons-graph {
+  position: absolute;
+  left: 40px;
+  top: 480px;
+  width: 220px;
+  overflow: auto;
+  overflow-y: auto;
 }

--- a/app/components/Graph.js
+++ b/app/components/Graph.js
@@ -4,12 +4,18 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import routes from '../constants/routes.json';
 import { withStyles } from '@material-ui/core/styles';
-import {FaArrowLeft} from 'react-icons/fa';
+import {FaArrowLeft, FaPlay, FaChartBar, FaStop, FaCopy, FaSave, FaTrashAlt, FaFolderOpen, FaPen} from 'react-icons/fa';
 import VialArrayGraph from './graphing/VialArrayGraph';
 import VialArrayBtns from './graphing/VialArrayBtns';
 import VialMenu from './graphing/VialMenu';
 import AceEditor from 'react-ace';
+import ReactTooltip from 'react-tooltip';
+const { ipcRenderer } = require('electron');
+import DeleteExptModal from './DeleteExptModal';
+import ModalClone from './python-shell/ModalClone';
 
+const remote = require('electron').remote;
+const app = remote.app;
 const { dialog } = require('electron').remote
 
 var path = require('path');
@@ -18,19 +24,25 @@ var zipdir = require('zip-dir');
 var fs = require('fs');
 var Tail = require('tail').Tail;
 var readline = require('readline');
+var rimraf = require('rimraf');
 
 const styles = {
 };
 
 const ymaxChoicesOD = ['0.1', '0.5', '1.0', '2.0'];
 const ymaxChoicesTemp = ['30', '35', '40', '45'];
-const xAxisNameOD = 'OPTICAL DENSITY'
-const xAxisNameTemp = 'TEMPERATURE (C)'
+const xAxisNameOD = 'OPTICAL DENSITY';
+const xAxisNameTemp = 'TEMPERATURE (C)';
+const filesToCopy = ['custom_script.py', 'eVOLVER.py', 'nbstreamreader.py', 'pump_cal.txt', 'eVOLVER_parameters.json'];
+
 
 class Graph extends React.Component {
   constructor(props) {
     super(props);
+    var exptName = path.basename(this.props.exptDir);
     this.state = {
+      exptDir: this.props.exptDir,
+      exptName: exptName,
       ymax: '0.5',
       ymaxChoices: ymaxChoicesOD,
       ymaxTitle: 'YAXIS - MAX VALUE',
@@ -46,8 +58,27 @@ class Graph extends React.Component {
       logToggleText: 'VIEW LOGS',
       logToggleOptions: ['VIEW GRAPH', 'VIEW LOGS'],
       logToggleState: true,
-      logData: ''
+      logData: '',
+      disablePlay: false,
+      changeNameDisabled: false,
+      deleteExptAlertOpen: false,
+      deleteExptAlertDirections: "",
+      cloneOpen: false,
+      cloneDirections: 'Enter a new experiment name:'
     };
+    ipcRenderer.on('running-expts', (event, arg) => {
+      var disablePlay = false;
+      var changeNameDisabled = false;
+      for (var i = 0; i < arg.length; i++) {
+        if (arg[i] === path.join(this.state.exptDir)) {
+          disablePlay = true;
+          changeNameDisabled = true;
+        }
+      }
+      this.setState({disablePlay: disablePlay, changeNameDisabled: changeNameDisabled});
+    });
+
+    ipcRenderer.send('running-expts');    
   }
 
   componentDidMount() {
@@ -151,9 +182,69 @@ class Graph extends React.Component {
   handleActivePlot = (event) => {
     this.setState({activePlot: event})
   }
+  
+  setAllGraphs = () => {
+    this.setState({activePlot: 'ALL'});
+  }
+  
+  handlePlay = (exptToPlay) => {
+      ipcRenderer.send('start-script', exptToPlay);
+      this.setState({disablePlay:true});
+  }
+  
+  onStop = (exptToStop) => {
+      ipcRenderer.send('stop-script', exptToStop);
+  }
+  
+  handleReset = (exptToStop) => {
+      var directions = "Are you sure you want to reset the experiment " + this.state.exptName + "?";
+      this.setState({deleteExptAlertDirections: directions}, function() {
+          this.setState({deleteExptAlertOpen: true});
+      }.bind(this));
+  }
+  
+  deleteExptAlertAnswer = (response) => {
+      this.setState({deleteExptAlertOpen: false});
+      if (response) {
+          if (this.state.disablePlay) {
+            ipcRenderer.send('stop-script', this.state.exptDir);
+          }          
+          if (fs.existsSync(path.join(this.state.exptDir, 'data'))) {
+            rimraf.sync(path.join(this.state.exptDir, 'data'));              
+          }          
+      }
+  }
+  
+  cloneExpt = () => {
+      this.setState({cloneOpen: true});
+  }
+  
+  onResumeClone = (exptName) => {
+      this.setState({cloneOpen: false});
+        if (exptName !== false) {
+          this.createNewExperiment(exptName);
+        }
+  }
+  
+    createNewExperiment = (exptName) => {
+        var newDir = path.join(app.getPath('userData'), 'experiments', exptName);
+        var oldDir = path.join(this.state.exptDir);
+        console.log(oldDir);
+        if (!fs.existsSync(newDir)) {
+            fs.mkdirSync(newDir);
+        }
+        filesToCopy.forEach(function (filename) {
+          if (fs.existsSync(path.join(oldDir, filename))) {
+            fs.copyFileSync(path.join(oldDir, filename), path.join(newDir, filename));
+          }
+        });
+    }  
 
   render() {
     const { classes } = this.props;
+      var backButton = this.state.activePlot == 'ALL' ? 
+        <Link className="backHomeBtn" style={{zIndex: '10', position: 'absolute', top: '5px', left: '-20px'}} id="experiments" to={{pathname:routes.EXPTMANAGER, socket: this.props.socket, logger:this.props.logger}}><FaArrowLeft/></Link> :
+        <button className="backHomeBtn" style={{zIndex: '10', position: 'absolute', top: '3px', left: '-55px'}}onClick={this.setAllGraphs}><FaArrowLeft/></button>;
       var exptName = path.basename(this.props.exptDir);
       var dataDisplay = this.state.logToggleState ?
         <VialArrayGraph
@@ -175,20 +266,26 @@ class Graph extends React.Component {
             showGutter={false}
             setOptions={{autoScrollEditorIntoView:true}}
             editorProps={{$blockScrolling: true}}/></div>
+      var exptControlButtons = <div class="expt-buttons-graph">
+        <ReactTooltip />
+        {this.state.disablePlay ? <button class="ebfe" data-tip="Stop the experiment (end data collection and end culture routines)" onClick={() => this.onStop(this.state.exptDir)}><FaStop size={25}/></button> : <button data-tip="Start experiment (begin collecting data and execute culture routine)" class="ebfe" onClick={() => this.handlePlay(this.state.exptDir)} disabled={this.state.changeNameDisabled}><FaPlay size={25}/></button>}
+        <button class="ebfe" data-tip="Reset experiment (delete all data)" onClick={() => this.handleReset(this.state.exptDir)}><FaTrashAlt size={25}/></button>
+        <button class="ebfe" data-tip="Clone this experiment, creating a new one with identical configuration" onClick={() => this.cloneExpt()}><FaCopy size={25}/></button>
+        </div>;
 
     return (
       <div>
-        <Link className="backHomeBtn" style={{zIndex: '10', position: 'absolute', top: '5px', left: '-20px'}} id="experiments" to={{pathname:routes.EXPTMANAGER, socket: this.props.socket, logger:this.props.logger}}><FaArrowLeft/></Link>
-                <h4 className="graphTitle">{exptName}</h4>
-                {dataDisplay}
-        <div style={{position: 'absolute', top: '100px', left: '-10px'}}>
+        {backButton}
+        <h4 className="graphTitle">{exptName}</h4>
+        {dataDisplay}
+        <div style={{position: 'absolute', top: '85px', left: '-10px'}}>
           <VialArrayBtns
             labels={this.state.parameterChoices}
             radioTitle = {this.state.parameterTitle}
             value={this.state.parameter}
             onSelectRadio={this.handleParameterSelect}/>
         </div>
-        <div style={{position: 'absolute', top: '185px', left: '-10px'}}>
+        <div style={{position: 'absolute', top: '155px', left: '-10px'}}>
           <VialArrayBtns
             labels={this.state.timePlottedChoices}
             radioTitle = {this.state.timePlottedTitle}
@@ -200,11 +297,23 @@ class Graph extends React.Component {
             value={this.state.ymax}
             onSelectRadio={this.handleYmax}/>
         </div>
+         {exptControlButtons}       
         <VialMenu onSelectGraph={this.handleActivePlot}/>
         <div className="dataActionButtons">
           <button className={"dataActionButton"} onClick={this.downloadData}>DOWNLOAD</button>
           <button className={"dataActionButton"} onClick={this.toggleLog}>{this.state.logToggleText}</button>
         </div>
+        <DeleteExptModal
+            alertOpen = {this.state.deleteExptAlertOpen}
+            alertQuestion = {this.state.deleteExptAlertDirections}
+            buttonText = "Reset"
+            useLink = {false}
+            value = {this.state.exptDir}
+            onAlertAnswer = {this.deleteExptAlertAnswer} />
+        <ModalClone
+          alertOpen= {this.state.cloneOpen}
+          alertQuestion = {this.state.cloneDirections}
+          onAlertAnswer = {this.onResumeClone}/>
       </div>
 
     );

--- a/app/components/graphing/VialArrayBtns.js
+++ b/app/components/graphing/VialArrayBtns.js
@@ -17,7 +17,7 @@ const styles = theme => ({
     borderRadius: '10px',
     display: 'flex',
     width: '300px',
-    padding: '0px 0px 30px 0px',
+    padding: '0px 0px 15px 0px',
     justifyContent: 'center',
   },
   label: {

--- a/app/components/graphing/VialMenu.js
+++ b/app/components/graphing/VialMenu.js
@@ -27,15 +27,15 @@ class VialMenu extends React.Component {
 
       <div style={{
         width:'300px',
-        height: '500px'}}>
+        height: '600px'}}>
 
-        <p style={{fontSize: '21px', fontWeight: 'bold', position: 'absolute', margin: '350px 0px 0px 40px' }}>INDIVIDUAL PLOTS</p>
+        <p style={{fontSize: '21px', fontWeight: 'bold', position: 'absolute', margin: '290px 0px 0px 40px' }}>INDIVIDUAL PLOTS</p>
         <div style={{
           width:'220px',
-          height: '200px',
+          height: '150px',
           padding: '0px 40px 0px 40px',
           position: 'absolute',
-          margin: '390px 0px 0px 75px'}}>
+          margin: '330px 0px 0px 75px'}}>
           {vialButtons.map((vialButton, index) => (
             <button
               className = 'vialPlotsMenuBtns'

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "css-loader": "^1.0.0",
     "detect-port": "^1.2.3",
     "electron": "^2.0.6",
-    "electron-builder": "^22.9.1",
+    "electron-builder": "22.10.5",
     "electron-devtools-installer": "^2.2.4",
     "electron-rebuild": "^1.8.2",
     "enzyme": "^3.3.0",


### PR DESCRIPTION
# What? Why?
Address #160 Adding control buttons for the experiment in the graphing page. Accidentally addressed #150 

Changes proposed in this pull request:
- Adding a play/stop button
- Adding a delete data button (reset data)
- Adding a clone expt button
- Small styling changes to make room for the buttons.

<img width="1104" alt="Screen Shot 2022-03-10 at 12 18 37 PM" src="https://user-images.githubusercontent.com/10240498/157718989-c8ec9ae0-8ee4-4786-a712-f908e81dc32a.png">
