### PR TITLE
Modals do not close on esc/click

### DIFF
--- a/app/components/DeleteExptModal.js
+++ b/app/components/DeleteExptModal.js
@@ -69,6 +69,8 @@ class DeleteExptModal extends React.Component {
       <div>
         <Modal
           open={open}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}
           onClose={this.onCloseModal}
           onRequestClose={this.onCloseModal}
           center

--- a/app/components/NewFileModal.js
+++ b/app/components/NewFileModal.js
@@ -59,6 +59,8 @@ class NewFileModal extends React.Component {
       <div>
         <Modal
           open={open}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}             
           onClose={this.onCloseModal}
           onRequestClose={this.onCloseModal}
           center

--- a/app/components/RelaunchModal.js
+++ b/app/components/RelaunchModal.js
@@ -57,6 +57,8 @@ class RelaunchModal extends React.Component {
       <div>
         <Modal
           open={open}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}          
           onClose={this.onCloseModal}
           onRequestClose={this.onCloseModal}
           center

--- a/app/components/calibrationInputs/ModalAlert.js
+++ b/app/components/calibrationInputs/ModalAlert.js
@@ -55,6 +55,8 @@ class ModalAlert extends React.Component {
       <div>
         <Modal
           open={open}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}             
           onClose={this.onCloseModal}
           center
           classNames={{

--- a/app/components/evolverConfigs/ConfigModal.js
+++ b/app/components/evolverConfigs/ConfigModal.js
@@ -107,6 +107,8 @@ class ConfigModal extends React.Component {
         {activeBtnLabel}
         <Modal
           open={open}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}          
           onClose={this.onCloseModal}
           classNames={{
              closeButton: styles.customcloseButton,

--- a/app/components/python-shell/ModalClone.js
+++ b/app/components/python-shell/ModalClone.js
@@ -77,6 +77,8 @@ class ModalClone extends React.Component {
       <div>
         <Modal
           open={open}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}
           onClose={this.onCloseModal}
           onRequestClose={this.onCloseModal}
           center

--- a/app/components/python-shell/ModalReset.js
+++ b/app/components/python-shell/ModalReset.js
@@ -61,6 +61,8 @@ class ModalReset extends React.Component {
       <div>
         <Modal
           open={open}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}          
           onClose={this.onCloseModal}
           onRequestClose={this.onCloseModal}
           center


### PR DESCRIPTION
# What? Why?
Modals would close by pressing esc or clicking outside the box, potentially leaving things in a weird state by not calling the expected callback functions. This requires that the buttons be pressed.

Changes proposed in this pull request:
- Set `closeOnEsc` to false for all modals
- Set `closeOnOverlayClick` to false for all modals
