### PR TITLE
python path comes from ENV variable

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -69,10 +69,11 @@ function storeRunningExpts() {
 /* Handle startup of a python shell instance to run the DPU */
 function startPythonExpt(exptDir, flag) {
   var scriptName = path.join(exptDir, 'eVOLVER.py');
+  var pythonPath = path.join(process.env.DPUENV, 'bin', 'python3')
   // We need to make the path a variable - needs to be either set by user or we require it to be installed at a specific location.
   var options = {
       mode: 'text',
-      pythonPath: '/Library/Frameworks/Python.framework/Versions/3.6/bin/python3',
+      pythonPath: pythonPath,
       args: flag
     };
   var pyShell = new PythonShell(scriptName, options);


### PR DESCRIPTION
# What? Why?
The python path for the node python shell needs to be specified for users with multiple python installations, or for venv usage. This change requires the user to specify the path to the python installation they would like to use in order to use the experiment manager. This will be further documented in a forum/wiki post.

Changes proposed in this pull request:
- Pull the python binary path from a system environment variable.