### PR TITLE
Adding chemostat editor page

### DIFF
--- a/app/components/ScriptEditor.js
+++ b/app/components/ScriptEditor.js
@@ -55,6 +55,7 @@ const styles = {
 
 const exptEditorOptions = [
   {value: 'turbidostat', label: 'Turbidostat'},
+  {value: 'chemostat', label:'Chemostat'},
   {value: 'growthcurve', label: 'Growth Curve'},
   {value: 'fileEditor', label: 'File Editor'}
 ]
@@ -292,12 +293,24 @@ class ScriptEditor extends React.Component {
   loadSaveParameters = () => {
       var filename = path.join(this.state.exptDir, 'eVOLVER_parameters.json');
       var vialConfiguration;
+      var vialConfigurationRaw;
       if (fs.existsSync(filename)) {
-          var vialConfigurationRaw = fs.readFileSync(filename);          
+          vialConfigurationRaw = fs.readFileSync(filename);          
           vialConfiguration = JSON.parse(vialConfigurationRaw)['vial_configuration'];
-      }
-      console.log(vialConfiguration);
+          vialConfigurationRaw = JSON.parse(vialConfigurationRaw);
+      }      
       this.setState({vialConfiguration: vialConfiguration});
+      if (vialConfigurationRaw) {
+        if (vialConfigurationRaw.function == 'turbidostat') {
+            this.setState({selectedEditor: exptEditorOptions.find(a => a.value == 'turbidostat')})
+        }
+        else if (vialConfigurationRaw.function == 'chemostat') {
+            this.setState({selectedEditor: exptEditorOptions.find(a => a.value == 'chemostat')})
+        }
+        else if (vialConfigurationRaw.fucntion == 'growthrate') {
+            this.setState({selectedEditor: exptEditorOptions.find(a => a.value == 'growthrate')})
+        }
+    }
   }
 
   handleSaveParameters = (vialData) => {
@@ -460,12 +473,8 @@ class ScriptEditor extends React.Component {
           {filesComponent}
           </div>;
     }
-    else if (this.state.selectedEditor.value == 'turbidostat') {
-      editorComponent = <div><TstatEditor onSave={this.handleSaveParameters} evolverIp={this.props.evolverIp} function={'turbidostat'} vialConfiguration={this.state.vialConfiguration}/></div>
-    }
-
-    else if (this.state.selectedEditor.value == 'growthcurve') {
-      editorComponent = <div><TstatEditor onSave={this.handleSaveParameters} evolverIp={this.props.evolverIp} function={'growthcurve'} vialConfiguration={this.state.vialConfiguration}/></div>
+    else {
+      editorComponent = <div><TstatEditor onSave={this.handleSaveParameters} evolverIp={this.props.evolverIp} function={this.state.selectedEditor.value} vialConfiguration={this.state.vialConfiguration}/></div>
     }
 
     return (

--- a/app/components/experiment-configuration/TstatButtonCards.js
+++ b/app/components/experiment-configuration/TstatButtonCards.js
@@ -13,6 +13,7 @@ import Card from '@material-ui/core/Card';
 
 import TempSlider from '../setupButtons/TempSlider'
 import StirSlider from '../setupButtons/StirSlider'
+import RateSlider from '../setupButtons/RateSlider'
 import UpperODSlider from '../setupButtons/UpperODSlider'
 import LowerODSlider from '../setupButtons/LowerODSlider'
 
@@ -46,6 +47,21 @@ const tutorialStepsGrowthRate = [
     outputTag: 'stir'
   }
 ];
+
+const tutorialStepsCStat = [
+    {
+        label: 'Rate',
+        outputTag: 'rate'
+    },
+    {
+        label: 'Temperature',
+        outputTag: 'temp',        
+    },
+    {
+        label: 'Stir',
+        outputTag: 'stir'
+    }
+]
 
 const styles = theme => ({
   root: {
@@ -107,6 +123,9 @@ function ActiveButtons(props) {
   if (currentTag === 'lower') {
     return <LowerODSlider onSubmitButton={props.onSubmitButton}/>;
   }
+  if (currentTag === 'rate') {
+      return <RateSlider onSubmitButton={props.onSubmitButton}/>;
+  }
   if (currentTag === 'temp') {
     return <TempSlider onSubmitButton={props.onSubmitButton}/>;
   }
@@ -149,7 +168,16 @@ class SwipeableTextMobileStepper extends React.Component {
     const { classes, theme } = this.props;
     const { activeStep } = this.state;
     var tutorialSteps;
-    var tutorialSteps = this.props.function == 'turbidostat' ? tutorialStepsTStat : tutorialStepsGrowthRate
+    var tutorialSteps;
+    if (this.props.function == 'turbidostat') {
+        tutorialSteps = tutorialStepsTStat;
+    }
+    else if (this.props.function == 'chemostat') {
+        tutorialSteps = tutorialStepsCStat;
+    }
+    else {
+        tutorialSteps = tutorialStepsGrowthRate;
+    }
     const maxSteps = tutorialSteps.length;
 
     return (

--- a/app/components/experiment-configuration/TstatEditor.js
+++ b/app/components/experiment-configuration/TstatEditor.js
@@ -8,6 +8,7 @@ import data from '../sample-data-tstat'
 import TstatButtonCards from './TstatButtonCards';
 import TempSlider from '../setupButtons/TempSlider';
 import StirSlider from '../setupButtons/StirSlider';
+import RateSlider from '../setupButtons/RateSlider';
 import UpperODSlider from '../setupButtons/UpperODSlider';
 import LowerODSlider from '../setupButtons/LowerODSlider';
 
@@ -42,6 +43,7 @@ const styles = {
 };
 
 const defaultTstatParameters = [{"vial":0,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":1,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":2,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":3,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":4,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":5,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":6,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":7,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":8,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":9,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":10,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":11,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":12,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":13,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":14,"temp":30,"stir":8,"upper":0.85,"lower":0.3},{"vial":15,"temp":30,"stir":8,"upper":0.85,"lower":0.3}];
+const defaultCstatParameters = [{"vial":0,"temp":30,"stir":8,"rate":0.5},{"vial":1,"temp":30,"stir":8,"rate":0.5},{"vial":2,"temp":30,"stir":8,"rate":0.5},{"vial":3,"temp":30,"stir":8,"rate":0.5},{"vial":4,"temp":30,"stir":8,"rate":0.5},{"vial":5,"temp":30,"stir":8,"rate":0.5},{"vial":6,"temp":30,"stir":8,"rate":0.5},{"vial":7,"temp":30,"stir":8,"rate":0.5},{"vial":8,"temp":30,"stir":8,"rate":0.5},{"vial":9,"temp":30,"stir":8,"rate":0.5},{"vial":10,"temp":30,"stir":8,"rate":0.5},{"vial":11,"temp":30,"stir":8,"rate":0.5},{"vial":12,"temp":30,"stir":8,"rate":0.5},{"vial":13,"temp":30,"stir":8,"rate":0.5},{"vial":14,"temp":30,"stir":8,"rate":0.5},{"vial":15,"temp":30,"stir":8,"rate":0.5}];
 const defaultGrowthRateParameters = [{"vial":0,"temp":30,"stir":8},{"vial":1,"temp":30,"stir":8},{"vial":2,"temp":30,"stir":8},{"vial":3,"temp":30,"stir":8},{"vial":4,"temp":30,"stir":8},{"vial":5,"temp":30,"stir":8},{"vial":6,"temp":30,"stir":8},{"vial":7,"temp":30,"stir":8},{"vial":8,"temp":30,"stir":8},{"vial":9,"temp":30,"stir":8},{"vial":10,"temp":30,"stir":8},{"vial":11,"temp":30,"stir":8},{"vial":12,"temp":30,"stir":8},{"vial":13,"temp":30,"stir":8},{"vial":14,"temp":30,"stir":8},{"vial":15,"temp":30,"stir":8}];
 
 var fs = require('fs');
@@ -50,11 +52,13 @@ var path = require('path');
 class TstatEditor extends React.Component {
     constructor(props) {
         super(props);
+        var vc = this.checkVialConfiguration();
         this.state = {
             vialData: data,
             rawData: [],
             selectedItems: [],
-            vialConfiguration: this.props.vialConfiguration
+            funct: this.props.function,
+            vialConfiguration: vc
         };
     }
 
@@ -64,30 +68,65 @@ class TstatEditor extends React.Component {
     
     componentDidUpdate(prevProps) {        
         if (this.props.vialConfiguration !== prevProps.vialConfiguration) {
-            this.setState({vialConfiguration: this.props.vialConfiguration}, () => {this.checkDefaults()});
+            var vc = this.checkVialConfiguration();
+            this.setState({vialConfiguration: vc}, () => {this.checkDefaults()});
         }
+        if (this.props.function !== prevProps.function) {
+            this.setState({funct: this.props.function}, () => {this.checkDefaults()});
+        }
+    }
+    
+    checkVialConfiguration = () => {
+        var vc;
+        if (this.props.vialConfiguration) {
+            vc = this.props.vialConfiguration;
+        }
+        else {
+            vc = [];
+        }      
+        return vc;
     }
 
     checkDefaults = () => {
-      if (this.props.function == 'turbidostat') {
-        if (this.props.vialConfiguration) {
-          this.readTStatParameters(this.state.vialConfiguration);  
+        console.log('checking defaults');
+      if (this.state.funct == 'turbidostat') {
+        if (this.state.vialConfiguration.length > 0) {
+            if ('upper' in this.state.vialConfiguration[0]) {
+                console.log(this.state.vialConfiguration[0])
+                this.readTstatParameters(this.state.vialConfiguration);
+            }
+            else {
+                this.readTstatParameters(defaultTstatParameters);
+            }
         }
         else {
-          this.readTStatParameters(defaultTstatParameters);
+          this.readTstatParameters(defaultTstatParameters);
         }
       }
-      else if (this.props.function == 'growthcurve') {
-          if(this.props.vialConfiguration) {
+      else if (this.state.funct == 'growthcurve') {
+          if(this.state.vialConfiguration.length > 0) {
             this.readGrowthRateParameters(this.state.vialConfiguration);   
           }
           else {
               this.readGrowthRateParameters(defaultGrowthRateParameters);
           }
-      }                
+      }
+      else if (this.state.funct == 'chemostat') {
+          if (this.state.vialConfiguration.length > 0) {
+              if ('rate' in this.state.vialConfiguration[0]) {
+                  this.readCstatParameters(this.state.vialConfiguration);
+              }
+              else {
+                  this.readCstatParameters(defaultCstatParameters);
+              }
+          }
+          else {
+              this.readCstatParameters(defaultCstatParameters);
+          }
+      }
     }
     
-    readTStatParameters = (tstatParameters) => {
+    readTstatParameters = (tstatParameters) => {
         var parameters = tstatParameters;
         var newRawData = parameters;
         parameters = this.formatVialSelectStrings(parameters, 'upper');
@@ -96,6 +135,15 @@ class TstatEditor extends React.Component {
         parameters = this.formatVialSelectStrings(parameters, 'stir');
         this.setState({vialData: parameters, rawData: newRawData});
     };
+    
+    readCstatParameters = (cstatParameters) => {
+        var parameters = cstatParameters;
+        var newRawData = parameters;
+        parameters = this.formatVialSelectStrings(parameters, 'rate');
+        parameters = this.formatVialSelectStrings(parameters, 'temp');
+        parameters = this.formatVialSelectStrings(parameters, 'stir');
+        this.setState({vialData:parameters, rawData: newRawData});
+    }
 
     readGrowthRateParameters = (tstatParameters) => {
         var parameters = tstatParameters;
@@ -111,12 +159,18 @@ class TstatEditor extends React.Component {
 
     formatVialSelectStrings = (vialData, parameter) => {
       var newData = JSON.parse(JSON.stringify(vialData));
+      if (parameter === 'rate') {
+          console.log(newData);
+      }
       for(var i = 0; i < newData.length; i++) {
         if (parameter === 'upper'){
           newData[i].upper = 'OD: ' + newData[i].upper;
         }
         if (parameter === 'lower') {
             newData[i].lower = newData[i].lower;
+        }
+        if (parameter === 'rate') {
+            newData[i].rate = 'Rate: ' + newData[i].rate + ' V/h';
         }
         if (parameter === 'temp'){
           newData[i].temp = newData[i].temp +'\u00b0C';
@@ -134,6 +188,9 @@ class TstatEditor extends React.Component {
         }
         if (component === 'lower') {
             value = value;
+        }
+        if (component === 'rate') {
+            value = 'Rate: ' + value + ' V/h';
         }
         if (component === 'temp'){
           value = value +'\u00b0C';
@@ -157,15 +214,23 @@ class TstatEditor extends React.Component {
 
     handleSave = () => {
         console.log('trying to save...');
-        var expt_config = {'function': this.state.function, 'ip': this.props.evolverIp, 'vial_configuration': this.state.rawData};
+        var expt_config = {'function': this.state.funct, 'ip': this.props.evolverIp, 'vial_configuration': this.state.rawData};
         console.log(expt_config);
         this.props.onSave(expt_config);
     }
     
     resetToDefault = () => {
         console.log('trying to reset...');
-        var expt_config = {'function': this.state.function, 'ip': this.props.evolverIp, 'vial_configuration': defaultTstatParameters};
-        this.setState({vialConfiguration: defaultTstatParameters}, () => {this.checkDefaults()});
+        var expt_config = {'function': this.state.funct, 'ip': this.props.evolverIp, 'vial_configuration': defaultTstatParameters};
+        if (this.state.funct == 'turbidostat') {
+            this.setState({vialConfiguration: defaultTstatParameters}, () => {this.checkDefaults()});
+        }
+        else if (this.state.funct == 'chemostat') {
+            this.setState({vialConfiguration: defaultCstatParameters}, () => {this.checkDefaults()});
+        }
+        else if (this.state.funct == 'growthcurve') {
+            this.setState({vialConfiguration: defaultGrowthCurveParameters}, () => {this.checkDefaults()});
+        }
         this.props.onSave(expt_config);       
     }
 
@@ -178,7 +243,7 @@ class TstatEditor extends React.Component {
                 <Card classes={{root:classes.cardRoot}} className={classes.tstatButtons}>
                     <TstatButtonCards
                       onSubmitButton={this.onSubmitButton}
-                      function={this.props.function}
+                      function={this.state.funct}
                       classes={classes.tstatButtons}
                        />
                 </Card>
@@ -189,7 +254,7 @@ class TstatEditor extends React.Component {
                         onSave={this.handleSave}
                         onResetToDefault={this.resetToDefault}
                         className={classes.temp}
-                        function={this.props.function}/>
+                        function={this.state.funct}/>
                 </Card>
                 </div>
             </div>

--- a/app/components/experiment-configuration/TstatVialSelector.css
+++ b/app/components/experiment-configuration/TstatVialSelector.css
@@ -140,6 +140,13 @@ button .tstat{
   color: white;
 }
 
+.rate-label {
+  font-size: 12px;
+  font-style: italic;
+  color: white;
+}
+
+
 .tstatSelectorButtons {
 display: inline-block;
   position: relative;

--- a/app/components/experiment-configuration/TstatVialSelector.js
+++ b/app/components/experiment-configuration/TstatVialSelector.js
@@ -46,6 +46,19 @@ const LabelTStat = ({ selecting, selected, vial, upper, lower, temp, stir}) => (
   </div>
 )
 
+const LabelCStat = ({ selecting, selected, vial, rate, temp, stir}) => (
+  <div
+  className="album-label">
+    <h2>
+    Vial <span>{`${vial}`}</span>
+    </h2>
+    <span className="rate-label"> {`${rate}`} </span><br/>
+    <span className="temp-label"> {`${temp}`} </span><br/>
+    <span className="stir-label"> {`${stir}`} </span>
+    <br />
+  </div>
+)
+
 const LabelGrowthCurve = ({ selecting, selected, vial, temp, stir}) => (
   <div
   className="album-label">
@@ -70,6 +83,24 @@ class TStatList extends Component {
         <div className="centered">
           {this.props.items.map((item) => (
             <SelectableAlbumTStat key={item.vial} vial={item.vial} selected={item.selected} upper={item.upper} lower={item.lower} temp={item.temp} stir={item.stir}/>
+          ))}
+        </div>
+      </div>
+    )
+  }
+}
+
+class CStatList extends Component {
+  componentDidUpdate(nextProps) {
+    return nextProps.items !== this.props.items
+  }
+
+  render() {
+    return (
+      <div style={{width: 560}}>
+        <div className="centered">
+          {this.props.items.map((item) => (
+            <SelectableAlbumCStat key={item.vial} vial={item.vial} selected={item.selected} rate={item.rate} temp={item.temp} stir={item.stir}/>
           ))}
         </div>
       </div>
@@ -113,6 +144,24 @@ const AlbumTStat = ({
   </div>
 )
 
+const AlbumCStat = ({
+  selectableRef, selected, selecting, strain, vial, rate, temp, stir
+}) => (
+  <div
+    id = {"vialID-" + vial}
+    ref={selectableRef}
+    className={`
+      ${(isDisabled(vial)) && 'not-selectable'}
+      item
+      ${selecting && 'selecting'}
+      ${selected && 'selected'}
+    `}
+  >
+    <div className="tick">+</div>
+    <LabelCStat selected={selected} selecting={selecting} vial={vial} strain={strain} rate={rate} temp={temp} stir={stir}/>
+  </div>
+)
+
 const AlbumGrowthCurve = ({
   selectableRef, selected, selecting, strain, vial, temp, stir
 }) => (
@@ -131,8 +180,9 @@ const AlbumGrowthCurve = ({
   </div>
 )
 
-const SelectableAlbumTStat = createSelectable(AlbumTStat)
-const SelectableAlbumGrowthCurve = createSelectable(AlbumGrowthCurve)
+const SelectableAlbumTStat = createSelectable(AlbumTStat);
+const SelectableAlbumCStat = createSelectable(AlbumCStat);
+const SelectableAlbumGrowthCurve = createSelectable(AlbumGrowthCurve);
 
 
 
@@ -192,6 +242,9 @@ class TstatVialSelector extends Component<Props>  {
     }
     else if (this.props.function == 'growthcurve') {
       list = <GrowthCurveList items={orderedItems}/>;
+    }
+    else if (this.props.function == 'chemostat') {
+      list = <CStatList items={orderedItems}/>;
     }
 
     return (

--- a/app/components/setupButtons/RateSlider.js
+++ b/app/components/setupButtons/RateSlider.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Slider from '@material-ui/lab/Slider';
+
+const styles = {
+  root: {
+    alignItems: 'center',
+    margin: '40px 20px 0px 50px',
+    width: '350px'
+  },
+  track: {
+    height: '5px',
+    backgroundColor: 'white',
+  },
+  thumb: {
+    width: '30px',
+    height: '30px',
+    opacity: 1,
+    backgroundColor: '#f58245',
+  },
+};
+
+class RateSlider extends React.Component {
+  state = {
+    value: 0.5,
+    min: 0,
+    max: 4,
+  };
+
+  handleChange = (event, value) => {
+    this.setState({ value });
+  };
+
+  clickAdd = (event,value) => {
+    let newValue = this.state.value + .01
+    if(newValue > this.state.max){
+      newValue = this.state.max;
+    }
+    this.setState({ value: newValue});
+  }
+
+  clickSubtract = (value) => {
+    let newValue = this.state.value - .01
+    if(newValue < this.state.min){
+      newValue = this.state.min;
+    }
+    this.setState({ value: newValue});
+  }
+
+  clickSubmit = (event) => {
+      this.props.onSubmitButton("rate", (Math.round(this.state.value * 100)/100).toFixed(2));
+  }
+
+  render() {
+    const { value } = this.state;
+    const { classes } = this.props;
+
+    return (
+      <div className="slider-style">
+        <span id="label">
+            <button type="button" className="btn btn-outline-secondary btn-circle setupButton" onClick={this.clickSubtract}><i className="fa fa-minus"></i></button>
+              <button className = "btn btn-lg btn-outline-secondary setupButton" onClick={this.clickSubmit}>
+                <span className="slider-label">
+                   Stir: {(Math.round(this.state.value * 100)/100).toFixed(2)}
+                </span>
+              </button>
+            <button type="button" className="btn btn-outline-secondary btn-circle setupButton" onClick={this.clickAdd}><i className="fa fa-plus"></i></button>
+          <Slider
+            value={value}
+            min={this.state.min}
+            max={this.state.max}
+            step={.01}
+            aria-labelledby="label"
+            onChange={this.handleChange}
+            classes={{
+              root: classes.root,
+              track: classes.track,
+              thumb: classes.thumb,
+            }}
+
+             />
+        </span>
+      </div>
+    );
+  }
+}
+
+RateSlider.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(RateSlider);


### PR DESCRIPTION
# What? Why?
Adding a chemostat page as a default editor. Common experimental use case.

Changes proposed in this pull request:
- Adding a `RateSlider` editor card for setting the flow rate for the chemostat.
- Addition of a chemostat option in the file editor dropdown
- Fixed some issues with the default values and which editor is brough up by default if an expt had been saved in the past.

# Any screenshots or GIFs?
<img width="1062" alt="Screen Shot 2022-03-24 at 12 49 21 PM" src="https://user-images.githubusercontent.com/10240498/159968287-945b6313-9538-4e8d-85a0-bc3c2be549b3.png">
