### PR TITLE
Graph axes sync with radio buttons and slider

### DIFF
--- a/app/components/Graph.js
+++ b/app/components/Graph.js
@@ -47,7 +47,7 @@ class Graph extends React.Component {
       ymaxChoices: ymaxChoicesOD,
       ymaxTitle: 'YAXIS - MAX VALUE',
       timePlotted: '5h',
-      timePlottedChoices: ['1h', '5h', '12h', '24h'],
+      timePlottedChoices: ['ALL', '5h', '12h', '24h'],
       timePlottedTitle: 'XAXIS - RECENT DATA:',
       downsample: 5,
       parameterChoices: ['OD', 'Temp'],
@@ -120,8 +120,8 @@ class Graph extends React.Component {
 
   handleTimePlotted = event => {
     var downsample;
-    if (event == '1h'){
-      downsample = 1;
+    if (event == 'ALL'){
+      downsample = -1;
     }
     if (event == '5h'){
       downsample = 5;
@@ -226,6 +226,10 @@ class Graph extends React.Component {
         }
   }
   
+  handleDataZoom = () => {
+      this.setState({timePlotted:'None'});      
+  }
+  
     createNewExperiment = (exptName) => {
         var newDir = path.join(app.getPath('userData'), 'experiments', exptName);
         var oldDir = path.join(this.state.exptDir);
@@ -254,7 +258,8 @@ class Graph extends React.Component {
             ymax={this.state.ymax}
             timePlotted={this.state.timePlotted}
             downsample = {this.state.downsample}
-            xaxisName = {this.state.xaxisName}/> :
+            xaxisName = {this.state.xaxisName}
+            onDataZoom = {this.handleDataZoom}/> :
         <div className="logViewer"><AceEditor
             value={this.state.logData}
             width='750px'

--- a/app/components/graphing/VialArrayBtns.js
+++ b/app/components/graphing/VialArrayBtns.js
@@ -59,7 +59,7 @@ class VialArrayBtns extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.labels !== prevProps.labels) {
+    if (this.props.labels !== prevProps.labels || this.props.value !== prevProps.value) {
       this.setState({
         labels: this.props.labels,
         value: this.props.value})

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -212,7 +212,7 @@ function createWindow () {
   mainWindow.loadURL(`file://${__dirname}/app.html`);
 
   // Uncomment to view dev tools on startup.
-  mainWindow.webContents.openDevTools();
+  //mainWindow.webContents.openDevTools();
 
   // @TODO: Use 'ready-to-show' event
   //        https://github.com/electron/electron/blob/master/docs/api/browser-window.md#using-ready-to-show-event


### PR DESCRIPTION
# What? Why?
Addresses #152 . Radio buttons sync to the graphs and when the data zoom tools is used.

Changes proposed in this pull request:
- Datazoom deselects the radio buttons for time
- Datazoom range persists between graphs
- Radio buttons now have an `ALL` setting to see all data.
- Downsampling is based on data length for ALL.