### PR TITLE
Graphic components for calibrations (temp and OD)

### DIFF
--- a/app/components/Calibrate.css
+++ b/app/components/Calibrate.css
@@ -198,7 +198,7 @@ ul {
 .odAdvanceBtn {
   position: absolute;
   margin: 540px 0px 0px 348px;
-  height: 80px;
+  height: 40px;
   width: 120px;
   background-color: white;
   color: black;
@@ -213,7 +213,7 @@ ul {
 .odBackBtn {
   position: absolute;
   margin: 540px 0px 0px 63px;
-  height: 80px;
+  height: 40px;
   width: 120px;
   background-color: white;
   color: black;
@@ -238,10 +238,30 @@ ul {
 .measureBtn {
   position: absolute;
   margin: 540px 0px 0px 196px;
-  height: 80px;
+  height: 40px;
   width: 140px;
   background-color: white;
   color: black;
+}
+
+.odViewGraphBtn {
+  position: absolute;
+  height: 40px;
+  width: 406px;
+  background-color: white;
+  color: black;
+  top: 590px;
+  left: 48px;
+}
+
+.odViewGraphBtnBack {
+  position: absolute;
+  height: 40px;
+  width: 150px;
+  background-color: white;
+  color: black;
+  top: 590px;
+  left: 48px;    
 }
 
 .statusText {
@@ -250,13 +270,13 @@ ul {
 
 .readStopBtn {
   position: absolute;
-  margin: 18px 0px 0px -33px;
+  margin: 8px 0px 0px -26px;
 }
 
 .tempAdvanceBtn {
   position: absolute;
   margin: 540px 0px 0px 348px;
-  height: 70px;
+  height: 40px;
   width: 120px;
   background-color: white;
   color: black;
@@ -271,7 +291,7 @@ ul {
 .tempBackBtn {
   position: absolute;
   margin: 540px 0px 0px 63px;
-  height: 70px;
+  height: 40px;
   width: 120px;
   background-color: white;
   color: black;
@@ -285,7 +305,7 @@ ul {
 .tempMeasureBtn {
   position: absolute;
   margin: 540px 0px 0px 196px;
-  height: 70px;
+  height: 40px;
   width: 140px;
   background-color: white;
   color: black;

--- a/app/components/Graph.js
+++ b/app/components/Graph.js
@@ -258,8 +258,10 @@ class Graph extends React.Component {
             ymax={this.state.ymax}
             timePlotted={this.state.timePlotted}
             downsample = {this.state.downsample}
-            xaxisName = {this.state.xaxisName}
-            onDataZoom = {this.handleDataZoom}/> :
+            yaxisName = {this.state.xaxisName}
+            xaxisName = {'EXPERIMENT TIME (h)'}
+            onDataZoom = {this.handleDataZoom}
+            dataType = {{type: 'experiment'}}/> :
         <div className="logViewer"><AceEditor
             value={this.state.logData}
             width='750px'

--- a/app/components/calibrationInputs/CalGUI.js
+++ b/app/components/calibrationInputs/CalGUI.js
@@ -160,15 +160,23 @@ export default class ODcalGUI extends Component<Props> {
 
   render() {
     const { odState } = this.state;
-
-    return(
-      <div>
+    let outputs;
+    if (this.props.displayGraphs) {
+        outputs = <div></div>
+    }
+    else {
+        outputs = 
+                      <div>
         <VialItem
           currentValue = {this.state.zipped}
         />
         <VialOutline
           readProgress = {this.state.readProgress}/>
       </div>
+    }
+
+    return(
+            <div>{outputs}</div>
 
     );
   }


### PR DESCRIPTION
# What? Why?
Allows users to see calibration data in mid calibration. Addresses 

Changes proposed in this pull request:
- Adding a button to view graphs.
- Graphs fill entire screen, back button and back arrow both go back to main cal page
- For temp and OD.

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
