### PR TITLE
Integrating calibrate.py and graphing of fits

### DIFF
--- a/app/components/PumpCalibrate.js
+++ b/app/components/PumpCalibrate.js
@@ -90,7 +90,7 @@ class PumpCal extends React.Component {
     for (var i = 0; i < data.length; i++) {
       vialData.push(Object.assign({},data[i]));
     }
-    this.state = {
+   this.state = {
       currentStep: 0,
       pumpCalModes: [{arrayName: 'IN1', arrayMode: 'NA'}, {arrayName: 'IN2', arrayMode: 'NA'}, {arrayName: 'E', arrayMode: 'NA'}],
       pumpCalModesFiltered: [],
@@ -118,7 +118,6 @@ class PumpCal extends React.Component {
         this.setState({alertQuestion: 'Successfully Logged. Do you want to exit?'})
       }
     }.bind(this));
-
   }
 
   componentWillUnmount() {
@@ -164,7 +163,7 @@ class PumpCal extends React.Component {
     }
     else {
       statusText = `Press PUMP to run ${pumpCalModes[currentStep-1].arrayName} for ${pumpTime} seconds`;
-    }    
+    }
     var buttonBackText;
     var buttonAdvanceText;
     if (currentStep === 1) {
@@ -258,9 +257,6 @@ class PumpCal extends React.Component {
    }
 
    onAlertAnswer = (answer) => {
-     if (answer == 'Retry'){
-       this.handleFinishExpt();
-     }
      if (answer == 'Exit'){
        store.delete('runningPumpCal');
        this.setState({exiting: true});


### PR DESCRIPTION
# What? Why?
Calibrations require running an additional python script after going through the GUI protocol. This integrates that python script into the GUI and plots data as it is collected to streamline the process. (For TEMP and OD cal pages)
Changes proposed in this pull request:
- Data can be viewed in graphs as it is collected via a button on OD and temp cal pages
- Submitting the cal also will call calibrate.py in the background.
- When calibrate.py finishes, graphs appear displaying the collected data with the fit overlayed.