### PR TITLE
Fixing setup page data display and cal graph range

### DIFF
--- a/app/components/Setup.js
+++ b/app/components/Setup.js
@@ -116,9 +116,16 @@ export default class Setup extends Component<Props> {
       rawData[i].vial = this.state.vialData[i].vial;
       rawData[i].selected = this.state.vialData[i].selected;
 
-      rawData[i].od_135 = responseData.od_135[i];
-      rawData[i].od_90 = responseData.od_90[i];
-      rawData[i].temp = responseData.temp[i];
+      if (responseData.od_135)
+      {
+          rawData[i].od_135 = responseData.od_135[i];          
+      }
+      if (responseData.od_90) {
+          rawData[i].od_90 = responseData.od_90[i];          
+      }
+      if (responseData.temp) {
+          rawData[i].temp = responseData.temp[i];          
+      }      
     }
     return rawData
   }

--- a/app/components/graphing/VialArrayGraph.js
+++ b/app/components/graphing/VialArrayGraph.js
@@ -305,7 +305,9 @@ class VialArrayGraph extends React.Component {
             }
           }
         }
-                
+        var percentage = maxDataPoint * .05;
+        minDataPoint = minDataPoint - percentage;
+        maxDataPoint = maxDataPOint + percentage;
         this.setState({ymin: minDataPoint, ymax: maxDataPoint});
         compiled_data[i] = data;
         compiledCalibrationData[i] = calibrationData;


### PR DESCRIPTION
# What? Why?
The setup page was not displaying data due to an error checking for `od_135`.
Changes proposed in this pull request:
- Check for parameters existing before accessing.
- Add 5% to graphing range in both min and max directions.