### PR TITLE
Fixes for db/gdrive syncing

### DIFF
--- a/app/components/ExptManager.js
+++ b/app/components/ExptManager.js
@@ -81,9 +81,9 @@ class ExptManager extends React.Component {
         console.log('We just got ip from main for some reason ' + arg);
       this.setState({evolverIp: arg});
       });
-    if (!fs.existsSync(path.join(this.state.exptLocation, this.state.scriptDir))) {
-      fs.mkdirSync(path.join(this.state.exptLocation, this.state.scriptDir));
-      fs.mkdirSync(path.join(this.state.exptLocation, 'template'));
+    if (!fs.existsSync(path.join(app.getPath('userData'), this.state.scriptDir))) {
+      fs.mkdirSync(path.join(app.getPath('userData'), this.state.scriptDir));
+      fs.mkdirSync(path.join(app.getPath('userData'), 'template'));
       var customScriptFile = fs.createWriteStream(path.join(this.state.exptLocation, 'template', 'custom_script.py'));
       var evolverFile = fs.createWriteStream(path.join(this.state.exptLocation, 'template', 'eVOLVER.py'));
       var nbstreamreaderFile = fs.createWriteStream(path.join(this.state.exptLocation, 'template', 'nbstreamreader.py'));
@@ -150,7 +150,7 @@ class ExptManager extends React.Component {
 
     createNewExperiment = (exptName) => {
         var newDir = path.join(this.state.exptLocation, this.state.scriptDir, exptName);
-        var oldDir = path.join(this.state.exptLocation, "template");
+        var oldDir = path.join(app.getPath('userData'), "template");
         if (!fs.existsSync(newDir)) {
             fs.mkdirSync(newDir);
         }

--- a/app/components/graphing/VialArrayGraph.js
+++ b/app/components/graphing/VialArrayGraph.js
@@ -138,6 +138,9 @@ class VialArrayGraph extends React.Component {
       if ((downsample === -1 && trimmedData.length > 5000) || this.state.useDatazoomForAll) {
         downsample = Math.ceil(trimmedData.length / 100);
       }
+      if (downsample === -1) {
+          downsample = 1;
+      }
       return downsample;
   }
 
@@ -311,7 +314,7 @@ class VialArrayGraph extends React.Component {
           for (var j = tempArray.length - 2 ; j > 1; j=j-downsample) {
             var parsed_value = tempArray[j].split(',')
             parsed_value[0] = parseFloat(parsed_value[0])
-            parsed_value[1] = parseFloat(Number(parsed_value[1]).toFixed(2))
+            parsed_value[1] = parseFloat(Number(parsed_value[1]).toFixed(2));
             if (this.state.useDatazoomForAll) {
                 if (parsed_value[0] >= lowerTime && parsed_value[0] <= upperTime) {
                     data.push(parsed_value)
@@ -327,9 +330,15 @@ class VialArrayGraph extends React.Component {
           }
         }
         var percentage = maxDataPoint * .03;
-        minDataPoint = Math.max(-0.1, minDataPoint - percentage);
-        maxDataPoint = maxDataPoint + percentage;
-        this.setState({ymin: minDataPoint, ymax: maxDataPoint});
+        if (this.props.dataType.type === 'calibration') {
+            minDataPoint = Math.max(-0.1, minDataPoint - percentage);
+            maxDataPoint = maxDataPoint + percentage;
+            this.setState({ymin: minDataPoint, ymax: maxDataPoint});            
+        }
+        else {
+            minDataPoint = this.state.ymin;
+            maxDataPoint = this.state.ymax;
+        }
         compiled_data[i] = data;
         compiledCalibrationData[i] = calibrationData;
         compiledErrorData[i] = errorData;


### PR DESCRIPTION
# What? Why?
The app was looking in the wrong place for template files after the expt location was changed.
Also fixed graphs display issues and downsampling for `ALL` data.
Changes proposed in this pull request:
- Look at appData location for templates
- Use appData location to make new expt
- Fix downsampling for `ALL` data range
- yMin/yMax should come from the buttons if graphing, otherwise use data range.
