### PR TITLE
update README/package.json for packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,15 @@ git commit -a --no-verify -m "Put comment here"
 
 ## Packaging
 
-To package apps for the local platform (Does not work well when compiling in other platforms. e.g. compile in OSX for OSX):
-
+To package for only your local platform:
 ```bash
 $ yarn package
+```
+
+To package apps for all platforms:
+
+```bash
+$ yarn package-all
 ```
 
 To package app for Raspberry Pi, first simulate Pi with Docker container:

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     },
     "win": {
       "target": [
-        "nsis"
+        "portable"
       ]
     },
     "linux": {
@@ -152,7 +152,7 @@
     "css-loader": "^1.0.0",
     "detect-port": "^1.2.3",
     "electron": "^2.0.6",
-    "electron-builder": "22.10.5",
+    "electron-builder": "~22.10.5",
     "electron-devtools-installer": "^2.2.4",
     "electron-rebuild": "^1.8.2",
     "enzyme": "^3.3.0",
@@ -246,10 +246,10 @@
     "react-select": "^2.4.0",
     "react-selectable-fast": "^2.1.1",
     "react-simple-keyboard": "1.15.2",
-    "react-tooltip": "4.2.17",
     "react-swipeable-views": "^0.13.0",
     "react-swipeable-views-utils": "^0.13.0",
     "react-table": "^6.9.2",
+    "react-tooltip": "4.2.17",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "socket.io-client": "^2.2.0",


### PR DESCRIPTION
# What? Why?
Updates documentation for instructions on packaging.

Changes proposed in this pull request:
- update README to include `yarn package-all`
- update package.json for electron-builder version to prevent a problem when installing dependencies