### PR TITLE
check OS version for path location for python

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -53,6 +53,8 @@ var maxShells = 5;
 var exptMap = {};
 var activeIp = '';
 
+var isWin = process.platform === "win32";
+
 /* Get array of running experiments from exptMap. Store path and pid information only. */
 function storeRunningExpts() {
   var runningExpts = Object.keys(exptMap).reduce(function(obj, x) {
@@ -72,7 +74,9 @@ function storeRunningExpts() {
 function startPythonExpt(exptDir, flag) {
   var scriptName = path.join(exptDir, 'eVOLVER.py');
   var pythonPath = path.join(store.get('dpu-env'), 'bin', 'python3');
-  console.log(pythonPath);
+  if (isWin) {
+    pythonPath = path.join(store.get('dpu-env'), 'Scripts', 'python');
+  }
   var options = {
       mode: 'text',
       pythonPath: pythonPath,
@@ -97,6 +101,9 @@ function startPythonExpt(exptDir, flag) {
 function startPythonCalibration(calibrationName, ip, fitType, fitName, params) {
     var scriptName = path.join(app.getPath('userData'), 'calibration', 'calibrate.py');
     var pythonPath = path.join(store.get('dpu-env'), 'bin', 'python3');
+    if (isWin) {
+        pythonPath = path.join(store.get('dpu-env'), 'Scripts', 'python');
+    }
     var options = {
         mode: 'text',
         pythonPath: pythonPath,

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eVOLVER",
   "productName": "eVOLVER",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Application to run eVOLVER on Desktop",
   "main": "./main.prod.js",
   "author": {


### PR DESCRIPTION
# What? Why?
Windows uses a different dir structure for the python venv binary location.
Changes proposed in this pull request:
- Check os in the main js file
- base `pythonPath` on OS.

Additionally updating the version to 2.0.